### PR TITLE
Remove unused code causing warnings

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210324/packages.dhall sha256:b4564d575da6aed1c042ca7936da97c8b7a29473b63f4515f09bb95fae8dddab
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.2-20210623/packages.dhall sha256:b3dcd9b0a1f6bffa4b5e61dc80e9f3fec2fca9405d591397a5076c8fe3aed1bc
 
 let overrides = {=}
 

--- a/src/PureScript/CST/Tidy.purs
+++ b/src/PureScript/CST/Tidy.purs
@@ -125,7 +125,7 @@ formatComment lineComment com next = case com of
         blockComment str `space` next
   Line _ n ->
     sourceBreak n next
-  Space n ->
+  Space _ ->
     next
 
 formatWithComments :: forall a. Array (Comment LineFeed) -> Array (Comment Void) -> FormatDoc a -> FormatDoc a

--- a/src/PureScript/CST/Tidy/Hang.purs
+++ b/src/PureScript/CST/Tidy/Hang.purs
@@ -99,7 +99,7 @@ toFormatDoc = unHangDoc <<< followLast HangStkRoot
       b
     a, HangEmpty ->
       formatBreak a
-    FormatDoc fl1 n1 m1 doc1 fr1, HangGroup _ docBreak (FormatDoc' _ _ _ _ fr2) ->
+    FormatDoc fl1 n1 m1 doc1 _, HangGroup _ docBreak (FormatDoc' _ _ _ _ fr2) ->
       HangGroup
         (forceBreaks n1 <> doc1 <> docBreak)
         (forceBreaks n1 <> doc1 <> docBreak)
@@ -111,7 +111,7 @@ toFormatDoc = unHangDoc <<< followLast HangStkRoot
       b
     a, HangEmpty ->
       formatBreak a
-    FormatDoc fl1 n1 m1 doc1 fr1, HangGroup docGroup _ (FormatDoc' _ _ _ _ fr2) -> do
+    FormatDoc fl1 n1 m1 doc1 _, HangGroup docGroup _ (FormatDoc' _ _ _ _ fr2) -> do
       let docIndent = ind docGroup
       HangGroup
         (Dodo.flexSelect
@@ -127,7 +127,7 @@ toFormatDoc = unHangDoc <<< followLast HangStkRoot
       b
     a, HangEmpty ->
       formatBreak a
-    FormatDoc fl1 n1 m1 doc1 fr1, HangGroup docGroup docBreak (FormatDoc' _ _ _ _ fr2) ->
+    FormatDoc fl1 n1 m1 doc1 _, HangGroup docGroup docBreak (FormatDoc' _ _ _ _ fr2) ->
       HangGroup
         (Dodo.flexSelect
           (withBreaks fl1 n1 doc1 (Dodo.spaceBreak <> doc1))

--- a/test/Snapshot.purs
+++ b/test/Snapshot.purs
@@ -92,7 +92,7 @@ snapshotFormat directory accept mbPattern = do
     let acceptOutput = writeFile outputPath =<< liftEffect (Buffer.fromString output UTF8)
     savedOutputFile <- try $ readFile outputPath
     case savedOutputFile of
-      Left err -> do
+      Left _ -> do
         acceptOutput
         pure { name, output, result: Saved }
       Right buffer -> do


### PR DESCRIPTION
This PR removes some unused code that is triggering warnings with PureScript 0.14.2. It also updates to the latest package set, which reduces the number of library warnings reported.