### PR TITLE
Add dev instructions for automatic formatting in VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,20 @@ spago -x ./test/spago.dhall test -a "--accept"
 ```sh
 spago -x ./script/spago.dhall run -m GenerateDefaultOperatorsModule
 ```
+
+### Auto-formatting in VS Code
+
+First, install the [Run on Save](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave) extension so that you can execute a command when your file is saved. Then, add this to your `settings.json`:
+
+```json
+  "emeraldwalk.runonsave": {
+    "commands": [
+      {
+        "match": ".purs",
+        "cmd": "$TIDY_DIR/bin/index.js format-in-place ${relativeFile}"
+      }
+    ]
+  }
+```
+
+...where `$TIDY_DIR` is replaced with the location of a checkout of `purescript-tidy`.


### PR DESCRIPTION
This PR adds instructions for how you can automatically run this formatter on save in VS Code. I'm sure similar workflows can be put in place for other environments, but several developers on this project use VS Code so I've added that first.

In action:

https://user-images.githubusercontent.com/10245104/128107928-1ab91f2c-d03d-404b-90a3-ee12d1965ec0.mov

