### PR TITLE
Add basic usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install -g purs-tidy
 
 ## Usage
 
-You can use `purs-tidy` to format files via STDIN / STDOUT or by modifying files in place:
+You can use `purs-tidy` to format files in place or via STDIN / STDOUT (which is useful for editor integration):
 
 ```sh
 # Formatting a collection of files in place:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ A syntax tidy-upper (formatter) for PureScript.
 npm install -g purs-tidy
 ```
 
+## Usage
+
+You can use `purs-tidy` to format files via STDIN / STDOUT or by modifying files in place:
+
+```sh
+# Formatting a collection of files in place:
+$ purs-tidy format-in-place "src/**/*.purs"
+
+# Using STDIN to format a file:
+$ purs-tidy format < MyFile.purs
+```
+
+### Configuration
+
+You can view the full configuration that `purs-tidy` accepts via flags here:
+https://github.com/natefaubion/purescript-tidy/blob/main/bin/Bin/FormatOptions.purs
+
+Some common options include:
+
+* `--indent` to set the number of spaces used in indentation, which defaults to 2 spaces
+* `--arrow-first` or `--arrow-last` to control whether type signatures put arrows first on the line or last on the line (purty-style), which defaults to arrow-last.
+
 ## Development
 
 ### Running `bin`

--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ $ purs-tidy format < MyFile.purs
 
 ### Configuration
 
-You can view the full configuration that `purs-tidy` accepts via flags here:
-https://github.com/natefaubion/purescript-tidy/blob/main/bin/Bin/FormatOptions.purs
+You can see all configuration that `purs-tidy` accepts using the `--help` flag for the command you are using:
+
+```sh
+$ purs-tidy format-in-place --help
+```
 
 Some common options include:
 


### PR DESCRIPTION
This PR adds some basic usage instructions to the README so that folks can immediately see how to run the tool using common flags. Admittedly, they could just install the tool and run `--help`, but I think it's helpful to make some of the config options discoverable right away. After all, opinions run rampant on arrow-first vs. arrow-last!