### PR TITLE
Add `check` command for finding unformatted files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "spago -x test/spago.dhall test",
     "generate-default-operators": "spago -x script/spago.dhall run -m GenerateDefaultOperatorsModule",
     "format-self": "npm run build && node ./bin/index.js format-in-place -af -un \"src/**/*.purs\" \"test/*.purs\" \"bin/**/*.purs\" \"script/**/*.purs\"",
+    "check-self": "npm run build && node ./bin/index.js check -af -un \"src/**/*.purs\" \"test/*.purs\" \"bin/**/*.purs\" \"script/**/*.purs\"",
     "prepublishOnly": "rm -rf output && npm run build"
   },
   "repository": {


### PR DESCRIPTION
Fixes #11. This PR implements a `check` command that will exit successfully if all files are formatted and otherwise will print out the paths of all unformatted files and exit with a failed status.

Example output:

```
$ purs-tidy check 'src/**/*.purs'
All files are formatted.
```

```
$ purs-tidy check ' src/**/*.purs' test/**/*.purs'
Some files have errors:

/Users/trh/trh/oss-other/purescript-tidy/test/Main.purs:
  Unexpected identifier import

Some files are not formatted:

  /Users/trh/trh/oss-other/purescript-tidy/test/Main.purs
  /Users/trh/trh/oss-other/purescript-tidy/src/PureScript/CST/Tidy/Token.purs
```

I'm intending this as more of a proposal than a finished feature; I'm happy to shuffle things around and change the output format as needed.