### PR TITLE
Implement `check` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Run tests
         run: spago --quiet --config test/spago.dhall test
+
+      - name: Verify formatting
+        run: npm run check-self

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ $ purs-tidy format-in-place "src/**/*.purs"
 $ purs-tidy format < MyFile.purs
 ```
 
+You can also use `purs-tidy` to verify whether files have already been formatted. This is often useful to verify, in continuous integration, that all project files are formatted according to the configuration. Files that would be changed by running `format-in-place` are listed out.
+
+```sh
+# Verifying files are formatted
+$ purs-tidy check "src/**/*.purs"
+All files are formatted.
+```
+
 ### Configuration
 
 You can see all configuration that `purs-tidy` accepts using the `--help` flag for the command you are using:
@@ -30,8 +38,8 @@ $ purs-tidy format-in-place --help
 
 Some common options include:
 
-* `--indent` to set the number of spaces used in indentation, which defaults to 2 spaces
-* `--arrow-first` or `--arrow-last` to control whether type signatures put arrows first on the line or last on the line (purty-style), which defaults to arrow-first.
+- `--indent` to set the number of spaces used in indentation, which defaults to 2 spaces
+- `--arrow-first` or `--arrow-last` to control whether type signatures put arrows first on the line or last on the line (purty-style), which defaults to arrow-first.
 
 You can generate a `.tidyrc.json` using the `generate-config` command. If a `.tidyrc.json` file is found, it will be used in lieu of CLI arguments.
 
@@ -61,6 +69,7 @@ spago -x ./bin/spago.dhall build
 ### Running `test`
 
 To accept snapshot tests:
+
 ```sh
 spago -x ./test/spago.dhall test -a "--accept"
 ```

--- a/bin/Main.purs
+++ b/bin/Main.purs
@@ -485,7 +485,7 @@ partitionCheckedFiles = do
           | otherwise = Array.cons (Tuple result.filePath result.error) errors
 
         notFormatted'
-          | not result.alreadyFormatted = notFormatted
+          | result.alreadyFormatted = notFormatted
           | otherwise = Array.cons result.filePath notFormatted
 
       { errors: errors', notFormatted: notFormatted' }

--- a/bin/Main.purs
+++ b/bin/Main.purs
@@ -470,7 +470,9 @@ tokenStreamToArray = go []
     TokenCons tok _ next _ ->
       go (Array.snoc acc tok.value) next
 
-partitionCheckedFiles :: Array WorkerOutput -> { errors :: Array (Tuple FilePath String), unformatted :: Array FilePath }
+partitionCheckedFiles
+  :: Array WorkerOutput
+  -> { errors :: Array (Tuple FilePath String), unformatted :: Array FilePath }
 partitionCheckedFiles = do
   let
     foldFn { errors, unformatted } result = do

--- a/bin/Main.purs
+++ b/bin/Main.purs
@@ -155,8 +155,7 @@ main = launchAff_ do
             FS.writeTextFile UTF8 rcFileName $ contents <> "\n"
 
         FormatInPlace mode cliOptions numThreads globs -> do
-          files <- expandGlobs
-              globs
+          files <- expandGlobs globs
           filesWithOptions <-
             flip evalStateT Map.empty do
               for files \filePath -> do

--- a/bin/Main.purs
+++ b/bin/Main.purs
@@ -154,7 +154,7 @@ main = launchAff_ do
             let contents = Json.stringifyWithIndent 2 $ FormatOptions.toJson cliOptions
             FS.writeTextFile UTF8 rcFileName $ contents <> "\n"
 
-        FormatInPlace cliOptions numThreads globs -> do
+        FormatInPlace mode cliOptions numThreads globs -> do
           files <- expandGlobs globs
           filesWithOptions <-
             flip evalStateT Map.empty do

--- a/bin/Main.purs
+++ b/bin/Main.purs
@@ -155,7 +155,8 @@ main = launchAff_ do
             FS.writeTextFile UTF8 rcFileName $ contents <> "\n"
 
         FormatInPlace mode cliOptions numThreads globs -> do
-          files <- expandGlobs globs
+          files <- expandGlobs
+              globs
           filesWithOptions <-
             flip evalStateT Map.empty do
               for files \filePath -> do

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "spago -x test/spago.dhall test",
     "generate-default-operators": "spago -x script/spago.dhall run -m GenerateDefaultOperatorsModule",
     "format-self": "npm run build && node ./bin/index.js format-in-place \"src/**/*.purs\" \"test/*.purs\" \"bin/**/*.purs\" \"script/**/*.purs\"",
+    "check-self": "npm run build && node ./bin/index.js check \"src/**/*.purs\" \"test/*.purs\" \"bin/**/*.purs\" \"script/**/*.purs\"",
     "prepublishOnly": "rm -rf output && npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build": "spago -x bin/spago.dhall build",
     "test": "spago -x test/spago.dhall test",
     "generate-default-operators": "spago -x script/spago.dhall run -m GenerateDefaultOperatorsModule",
-    "format-self": "npm run build && node ./bin/index.js format-in-place src test/Test bin script",
-    "check-self": "node ./bin/index.js check src test/Test bin script",
+    "format-self": "npm run build && node ./bin/index.js format-in-place src 'test/*.purs' bin script",
+    "check-self": "node ./bin/index.js check src 'test/*.purs' bin script",
     "prepublishOnly": "rm -rf output && npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build": "spago -x bin/spago.dhall build",
     "test": "spago -x test/spago.dhall test",
     "generate-default-operators": "spago -x script/spago.dhall run -m GenerateDefaultOperatorsModule",
-    "format-self": "npm run build && node ./bin/index.js format-in-place src test bin script",
-    "check-self": "node ./bin/index.js check src test bin script",
+    "format-self": "npm run build && node ./bin/index.js format-in-place src test/Test bin script",
+    "check-self": "node ./bin/index.js check src test/Test bin script",
     "prepublishOnly": "rm -rf output && npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build": "spago -x bin/spago.dhall build",
     "test": "spago -x test/spago.dhall test",
     "generate-default-operators": "spago -x script/spago.dhall run -m GenerateDefaultOperatorsModule",
-    "format-self": "npm run build && node ./bin/index.js format-in-place \"src/**/*.purs\" \"test/*.purs\" \"bin/**/*.purs\" \"script/**/*.purs\"",
-    "check-self": "npm run build && node ./bin/index.js check \"src/**/*.purs\" \"test/*.purs\" \"bin/**/*.purs\" \"script/**/*.purs\"",
+    "format-self": "npm run build && node ./bin/index.js format-in-place src test bin script",
+    "check-self": "node ./bin/index.js check src test bin script",
     "prepublishOnly": "rm -rf output && npm run build"
   },
   "repository": {


### PR DESCRIPTION
Fixes #11. This PR implements a `check` command that will exit successfully if all files are formatted and otherwise will print out the paths of all not-formatted files and exit with a failed status.

On success:

```
λ ./bin/index.js check "src/**/*.purs"                        
All files are formatted.
```

On formatting failure:

```
λ ./bin/index.js check "src/**/*.purs"
Some files are not formatted:

/Users/trh/trh/oss-other/purescript-tidy/src/PureScript/CST/Tidy/Precedence.purs
```

On formatting failure and errors (any error will fail the formatting check, too):

```
λ ./bin/index.js check "src/**/*.purs"
Some files have errors:

/Users/trh/trh/oss-other/purescript-tidy/src/PureScript/CST/Tidy/Precedence.purs:
  Unexpected identifier nsertOperator

Some files are not formatted:

/Users/trh/trh/oss-other/purescript-tidy/src/PureScript/CST/Tidy/Precedence.purs
/Users/trh/trh/oss-other/purescript-tidy/src/PureScript/CST/Tidy/Hang.purs
```