### PR TITLE
sh -> console in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,32 @@ A syntax tidy-upper (formatter) for PureScript.
 
 ## Install
 
-```sh
-npm install -g purs-tidy
+```console
+$ npm install -g purs-tidy
 ```
 
 ## Usage
 
 You can use `purs-tidy` to format files in place or via STDIN / STDOUT (which is useful for editor integration):
 
-```sh
-# Formatting a collection of files in place:
-$ purs-tidy format-in-place "src/**/*.purs"
+##### Formatting a collection of files in place:
 
-# Using STDIN to format a file:
+```console
+$ purs-tidy format-in-place "src/**/*.purs"
+```
+
+##### Using STDIN to format a file:
+
+```console
 $ purs-tidy format < MyFile.purs
 ```
 
 You can also use `purs-tidy` to verify whether files have already been formatted. This is often useful to verify, in continuous integration, that all project files are formatted according to the configuration. Files that would be changed by running `format-in-place` are listed out.
 
-```sh
-# Verifying files are formatted
+
+##### Verifying files are formatted
+
+```console
 $ purs-tidy check "src/**/*.purs"
 All files are formatted.
 ```
@@ -32,7 +38,7 @@ All files are formatted.
 
 You can see all configuration that `purs-tidy` accepts using the `--help` flag for the command you are using:
 
-```sh
+```console
 $ purs-tidy format-in-place --help
 ```
 
@@ -52,32 +58,32 @@ from the core and contrib organizations. If you need support for more
 operators, you can generate your own table using the `generate-operators`
 command.
 
-```sh
-purs-tidy generate-operators $(spago sources) > .tidyoperators
-purs-tidy generate-config --arrow-first --unicode-never --operators .tidyoperators
+```console
+$ purs-tidy generate-operators $(spago sources) > .tidyoperators
+$ purs-tidy generate-config --arrow-first --unicode-never --operators .tidyoperators
 ```
 
 ## Development
 
 ### Running `bin`
 
-```sh
-spago -x ./bin/spago.dhall build
-./bin/index.js --help
+```console
+$ spago -x ./bin/spago.dhall build
+$ ./bin/index.js --help
 ```
 
 ### Running `test`
 
 To accept snapshot tests:
 
-```sh
-spago -x ./test/spago.dhall test -a "--accept"
+```console
+$ spago -x ./test/spago.dhall test -a "--accept"
 ```
 
 ### Generating the built-in operator table
 
-```sh
-spago -x ./script/spago.dhall run -m GenerateDefaultOperatorsModule
+```console
+$ spago -x ./script/spago.dhall run -m GenerateDefaultOperatorsModule
 ```
 
 ### Auto-formatting in VS Code


### PR DESCRIPTION
This makes it more consistent and could be used to show console output as is the case with `All files are formatted.` Maybe a global sweep is not the best call, but some of these (c/sh)ould be `console`.

See it rendered with GitHub-flavored Markdown at the patch: https://github.com/toastal/purescript-tidy/tree/patch-1