### PR TITLE
Table of Contents via AsciiDoc + editor section moved

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,55 +1,62 @@
-# purescript-tidy
+purescript-tidy
+===============
+:toc:
+:toc-placement: preamble
+:toclevels: 3
+:showtitle:
 
 A syntax tidy-upper (formatter) for PureScript.
 
-## Install
+== Install
 
-```console
+[source,console]
+----
 $ npm install -g purs-tidy
-```
+----
 
-## Usage
+== Usage
 
 You can use `purs-tidy` to format files in place or via STDIN / STDOUT (which is useful for editor integration):
 
-##### Formatting a collection of files in place:
-
-```console
+.Formatting a collection of files in place:
+[source,console]
+----
 $ purs-tidy format-in-place "src/**/*.purs"
-```
+----
 
-##### Using STDIN to format a file:
-
-```console
+.Using STDIN to format a file:
+[source,console]
+----
 $ purs-tidy format < MyFile.purs
-```
+----
 
 You can also use `purs-tidy` to verify whether files have already been formatted. This is often useful to verify, in continuous integration, that all project files are formatted according to the configuration. Files that would be changed by running `format-in-place` are listed out.
 
 
-##### Verifying files are formatted
-
-```console
+.Verifying files are formatted
+[source,console]
+----
 $ purs-tidy check "src/**/*.purs"
 All files are formatted.
-```
+----
 
-### Configuration
+=== Configuration
 
 You can see all configuration that `purs-tidy` accepts using the `--help` flag for the command you are using:
 
-```console
+[source,console]
+----
 $ purs-tidy format-in-place --help
-```
+----
 
 Some common options include:
 
-- `--indent` to set the number of spaces used in indentation, which defaults to 2 spaces
-- `--arrow-first` or `--arrow-last` to control whether type signatures put arrows first on the line or last on the line (purty-style), which defaults to arrow-first.
+* `--indent` to set the number of spaces used in indentation, which defaults to 2 spaces
+* `--arrow-first` or `--arrow-last` to control whether type signatures put arrows first on the line or last on the line (purty-style), which defaults to arrow-first.
 
 You can generate a `.tidyrc.json` using the `generate-config` command. If a `.tidyrc.json` file is found, it will be used in lieu of CLI arguments.
 
-### Operator Precedence
+=== Operator Precedence
 
 To support correct operator precedence without having to parse your entire
 source tree (potentially for a single file), `purs-tidy` uses a pre-baked
@@ -58,58 +65,35 @@ from the core and contrib organizations. If you need support for more
 operators, you can generate your own table using the `generate-operators`
 command.
 
-```console
+[source,console]
+----
 $ purs-tidy generate-operators $(spago sources) > .tidyoperators
 $ purs-tidy generate-config --arrow-first --unicode-never --operators .tidyoperators
-```
+----
 
-## Development
+== Editor Support
 
-### Running `bin`
+=== Vim
 
-```console
-$ spago -x ./bin/spago.dhall build
-$ ./bin/index.js --help
-```
-
-### Running `test`
-
-To accept snapshot tests:
-
-```console
-$ spago -x ./test/spago.dhall test -a "--accept"
-```
-
-### Generating the built-in operator table
-
-```console
-$ spago -x ./script/spago.dhall run -m GenerateDefaultOperatorsModule
-```
-
-## Editor Support
-
-* [Vim](#vim)
-* [VS Code](#vs-code)
-
-### Vim
-
-#### via [ALE](https://github.com/dense-analysis/ale)
+==== https://github.com/dense-analysis/ale[ALE]
 
 Add to your other fixers `.vimrc` or `$XDG_CONFIG_HOME/neovim/init.vim`
 
-```viml
+[source,viml]
+----
 let b:ale_fixers = { 'purescript': [ 'purs-tidy' ] }
 " suggested to fix on save
 let g:ale_fix_on_save = 1
-```
+----
 
-### VS Code
+=== VS Code
 
-#### via [Run on Save](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave) 
+==== https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave[Run on Save]
 
 Add this to your `settings.json`:
 
-```json
+[source,json]
+----
   "emeraldwalk.runonsave": {
     "commands": [
       {
@@ -118,6 +102,28 @@ Add this to your `settings.json`:
       }
     ]
   }
-```
+----
 
 ...where `$TIDY_DIR` is replaced with the location of a checkout of `purescript-tidy`.
+
+== Development
+
+.Running `bin`
+[source,console]
+----
+$ spago -x ./bin/spago.dhall build
+$ ./bin/index.js --help
+----
+
+.Running `test` to accept snapshot tests:
+[source,console]
+----
+$ spago -x ./test/spago.dhall test -a "--accept"
+----
+
+.Generating the built-in operator table
+[source,console]
+----
+$ spago -x ./script/spago.dhall run -m GenerateDefaultOperatorsModule
+----
+

--- a/README.md
+++ b/README.md
@@ -86,9 +86,28 @@ $ spago -x ./test/spago.dhall test -a "--accept"
 $ spago -x ./script/spago.dhall run -m GenerateDefaultOperatorsModule
 ```
 
-### Auto-formatting in VS Code
+## Editor Support
 
-First, install the [Run on Save](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave) extension so that you can execute a command when your file is saved. Then, add this to your `settings.json`:
+* [Vim](#vim)
+* [VS Code](#vs-code)
+
+### Vim
+
+#### via [ALE](https://github.com/dense-analysis/ale)
+
+Add to your other fixers `.vimrc` or `$XDG_CONFIG_HOME/neovim/init.vim`
+
+```viml
+let b:ale_fixers = { 'purescript': [ 'purs-tidy' ] }
+" suggested to fix on save
+let g:ale_fix_on_save = 1
+```
+
+### VS Code
+
+#### via [Run on Save](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave) 
+
+Add this to your `settings.json`:
 
 ```json
   "emeraldwalk.runonsave": {


### PR DESCRIPTION
This would be _a_ way to get some more navigability out of the README ... at the cost of not using more-people-are-familiar-with GitHub-flavored Markdown and instead using AsciiDoc ([a cheatsheet](https://gist.github.com/powerman/d56b2675dfed38deb298)).

See rendered here: https://github.com/toastal/purescript-tidy/tree/editor-support-asciidoc
Raw: https://raw.githubusercontent.com/toastal/purescript-tidy/editor-support-asciidoc/README.adoc

Do feel free to straight-up **close** if that's not the direction you are headed. It didn't take much time but I figured it'd be an interesting comparison :shrug: 