### PR TITLE
Update VS Code plugin instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ let g:ale_fix_on_save = 1
 Add this to your `settings.json`:
 
 ```json
-  customLocalFormatters.formatters": [
-    {
-      "command": "purs-tidy format",
-      "languages": ["purescript"]
-    }
-  ]
+"customLocalFormatters.formatters": [
+  {
+    "command": "purs-tidy format",
+    "languages": ["purescript"]
+  }
+]
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -63,28 +63,6 @@ $ purs-tidy generate-operators $(spago sources) > .tidyoperators
 $ purs-tidy generate-config --arrow-first --unicode-never --operators .tidyoperators
 ```
 
-## Development
-
-### Running `bin`
-
-```console
-$ spago -x ./bin/spago.dhall build
-$ ./bin/index.js --help
-```
-
-### Running `test`
-
-To accept snapshot tests:
-
-```console
-$ spago -x ./test/spago.dhall test -a "--accept"
-```
-
-### Generating the built-in operator table
-
-```console
-$ spago -x ./script/spago.dhall run -m GenerateDefaultOperatorsModule
-```
 
 ## Editor Support
 
@@ -105,19 +83,40 @@ let g:ale_fix_on_save = 1
 
 ### VS Code
 
-#### via [Run on Save](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave) 
+#### via [Custom Local Formatters](https://marketplace.visualstudio.com/items?itemName=jkillian.custom-local-formatters) 
 
 Add this to your `settings.json`:
 
 ```json
-  "emeraldwalk.runonsave": {
-    "commands": [
-      {
-        "match": ".purs",
-        "cmd": "$TIDY_DIR/bin/index.js format-in-place ${relativeFile}"
-      }
-    ]
-  }
+  customLocalFormatters.formatters": [
+    {
+      "command": "purs-tidy format",
+      "languages": ["purescript"]
+    }
+  ]
 ```
 
-...where `$TIDY_DIR` is replaced with the location of a checkout of `purescript-tidy`.
+## Development
+
+### Running `bin`
+
+```console
+$ spago -x ./bin/spago.dhall build
+$ ./bin/index.js --help
+```
+
+If you would like to use your local build of `purs-tidy` in your editor, use path to `bin/index.js` instead of the `purs-tidy` binary in your settings. For example, instead of setting the format command to `purs-tidy format`, set it to `$TIDY_DIR/bin/index.js format` where `$TIDY_DIR` is the location of your checkout of this repository.
+
+### Running `test`
+
+To accept snapshot tests:
+
+```console
+$ spago -x ./test/spago.dhall test -a "--accept"
+```
+
+### Generating the built-in operator table
+
+```console
+$ spago -x ./script/spago.dhall run -m GenerateDefaultOperatorsModule
+```


### PR DESCRIPTION
This updates the instructions for using `purs-tidy` in VS Code. We've found the custom formatters plugin is much better than run on save because it hooks in to VS Code's formatting events directly.

I have also made two other changes:

- I moved 'editor support' above 'development' because it is now more user-facing than developer-facing
- I updated the VS Code instructions to use the `purs-tidy` binary, since that's what users will want; I added a line to the development instructions about using the `bin/index.js` script when doing local development and it should work for any editor, not just VS Code.