### PR TITLE
Update VS Code instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ $ purs-tidy generate-operators $(spago sources) > .tidyoperators
 $ purs-tidy generate-config --arrow-first --unicode-never --operators .tidyoperators
 ```
 
-
 ## Editor Support
 
 * [Vim](#vim)
@@ -83,17 +82,12 @@ let g:ale_fix_on_save = 1
 
 ### VS Code
 
-#### via [Custom Local Formatters](https://marketplace.visualstudio.com/items?itemName=jkillian.custom-local-formatters) 
+#### via [Purescript IDE](https://marketplace.visualstudio.com/items?itemName=nwolverson.ide-purescript)
 
-Add this to your `settings.json`:
+The PureScript IDE plugin for VS Code supports `purs-tidy` as a built-in formatter in versions after `0.25.1`. Choose `purs-tidy` from the list of supported formatters in the settings, or add this to your `settings.json`:
 
 ```json
-"customLocalFormatters.formatters": [
-  {
-    "command": "purs-tidy format",
-    "languages": ["purescript"]
-  }
-]
+"purescript.formatter": "purs-tidy"
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ let g:ale_fix_on_save = 1
 
 ### VS Code
 
-#### via [Purescript IDE](https://marketplace.visualstudio.com/items?itemName=nwolverson.ide-purescript)
+#### via [PureScript IDE](https://marketplace.visualstudio.com/items?itemName=nwolverson.ide-purescript)
 
 The PureScript IDE plugin for VS Code supports `purs-tidy` as a built-in formatter in versions after `0.25.1`. Choose `purs-tidy` from the list of supported formatters in the settings, or add this to your `settings.json`:
 


### PR DESCRIPTION
The PureScript IDE plugin for VS Code supports purs-tidy as a formatter as of https://github.com/nwolverson/vscode-ide-purescript/commit/c135afc385d0ab4b017ce6a723c7ea5ef487793f (v0.25.1).