### PR TITLE
Fix multiline operands without hangs

### DIFF
--- a/src/PureScript/CST/Tidy.purs
+++ b/src/PureScript/CST/Tidy.purs
@@ -835,7 +835,7 @@ formatCaseBranch :: forall e a. Format (Tuple (Separated (Binder e)) (Guarded e)
 formatCaseBranch conf (Tuple (Separated { head, tail }) guarded) =
   case guarded of
     Unconditional tok (Where { expr, bindings }) ->
-      flexGroup caseBinders
+      caseBinders
         `space`
           Hang.toFormatDoc (formatToken conf tok `hang` formatHangingExpr conf expr)
         `break`

--- a/src/PureScript/CST/Tidy.purs
+++ b/src/PureScript/CST/Tidy.purs
@@ -57,7 +57,7 @@ defaultFormatOptions :: forall e a. FormatError e => FormatOptions e a
 defaultFormatOptions =
   { formatError
   , unicode: UnicodeSource
-  , typeArrowPlacement: TypeArrowLast
+  , typeArrowPlacement: TypeArrowFirst
   , operators: Map.empty
   }
 

--- a/src/PureScript/CST/Tidy.purs
+++ b/src/PureScript/CST/Tidy.purs
@@ -805,7 +805,7 @@ toElseIfChain ifte = go (pure (IfThen ifte.keyword ifte.cond ifte.then ifte.true
       NonEmptyArray.snoc acc (Else curr.else expr)
 
 formatElseIfChain :: forall e a. Format (NonEmptyArray (ElseIfChain e)) e a
-formatElseIfChain conf = joinWithMap flexSpaceBreak case _ of
+formatElseIfChain conf = flexGroup <<< joinWithMap spaceBreak case _ of
   IfThen kw1 cond kw2 expr ->
     formatToken conf kw1
       `flexSpaceBreak`
@@ -917,7 +917,7 @@ formatValueBinding conf { name, binders, guarded } =
           indent do
             joinWithMap spaceBreak (anchor <<< formatBinder conf) binders
         `space`
-          Hang.toFormatDoc (indent (formatToken conf tok) `hang` formatHangingExpr conf expr)
+          Hang.toFormatDoc (indent (anchor (formatToken conf tok)) `hang` formatHangingExpr conf expr)
         `break`
           indent (foldMap (formatWhere conf) bindings)
 

--- a/src/PureScript/CST/Tidy/Doc.purs
+++ b/src/PureScript/CST/Tidy/Doc.purs
@@ -6,6 +6,7 @@ module PureScript.CST.Tidy.Doc
   , trailingLineComment
   , blockComment
   , anchor
+  , flatten
   , forceBreak
   , indent
   , align
@@ -78,6 +79,13 @@ anchor = case _ of
     FormatEmpty
   FormatDoc fl n m doc fr ->
     FormatDoc fl 0 (if n > 0 then true else m) doc fr
+
+flatten :: forall a. FormatDoc a -> FormatDoc a
+flatten = case _ of
+  FormatEmpty ->
+    FormatEmpty
+  FormatDoc fl n m doc fr ->
+    FormatDoc fl 0 m doc fr
 
 forceBreak :: forall a. FormatDoc a -> FormatDoc a
 forceBreak = case _ of

--- a/src/PureScript/CST/Tidy/Doc.purs
+++ b/src/PureScript/CST/Tidy/Doc.purs
@@ -84,7 +84,7 @@ flatten :: forall a. FormatDoc a -> FormatDoc a
 flatten = case _ of
   FormatEmpty ->
     FormatEmpty
-  FormatDoc fl n m doc fr ->
+  FormatDoc fl _ m doc fr ->
     FormatDoc fl 0 m doc fr
 
 forceBreak :: forall a. FormatDoc a -> FormatDoc a

--- a/src/PureScript/CST/Tidy/Hang.purs
+++ b/src/PureScript/CST/Tidy/Hang.purs
@@ -130,7 +130,7 @@ toFormatDoc = unHangDoc <<< followLast HangStkRoot
         (forceBreaks n1 <> doc1 <> docBreak)
         (forceBreaks n1 <> doc1 <> docBreak)
         ( FormatDoc' fl1 n1
-            (isMultiline a || isMultiline' b)
+            (isMultilineJoin a b)
             (Dodo.flexGroup doc1 <> docBreak)
             fr2
         )
@@ -151,7 +151,7 @@ toFormatDoc = unHangDoc <<< followLast HangStkRoot
         )
         (forceBreaks n1 <> doc1 <> docIndent)
         ( FormatDoc' fl1 n1
-            (isMultiline a || isMultiline' b)
+            (isMultilineJoin a b)
             (Dodo.flexGroup doc1 <> docIndent)
             fr2
         )
@@ -171,7 +171,7 @@ toFormatDoc = unHangDoc <<< followLast HangStkRoot
         )
         (forceBreaks n1 <> doc1 <> docBreak)
         ( FormatDoc' fl1 n1
-            (isMultiline a || isMultiline' b)
+            (isMultilineJoin a b)
             ( Dodo.flexSelect
                 (withBreaks fl1 n1 doc1 doc1)
                 docGroup
@@ -196,7 +196,7 @@ toFormatDoc = unHangDoc <<< followLast HangStkRoot
         )
         (forceBreaks n1 <> doc1 <> docIndent)
         ( FormatDoc' fl1 n1
-            (isMultiline a || isMultiline' b)
+            (isMultilineJoin a b)
             ( Dodo.flexGroup doc1 <>
                 if fr1 == ForceBreak || fl2 == ForceBreak || n2 > 0 then
                   Dodo.indent docBreak
@@ -238,19 +238,16 @@ withBreaks fl n doc1 doc2
   | n > 0 || fl == ForceBreak = forceBreaks n <> doc1
   | otherwise = doc2
 
-isMultiline :: forall a. FormatDoc a -> Boolean
-isMultiline = case _ of
-  FormatEmpty ->
-    false
-  FormatDoc fl n m _ fr ->
-    fl == ForceBreak
-      || n > 0
-      || m
+isMultilineJoin :: forall a. FormatDoc a -> FormatDoc' a -> Boolean
+isMultilineJoin = case _, _ of
+  FormatEmpty, FormatDoc' fl n m _ fr ->
+    m
+      || fl == ForceBreak
       || fr == ForceBreak
-
-isMultiline' :: forall a. FormatDoc' a -> Boolean
-isMultiline' (FormatDoc' fl n m _ fr) =
-  fl == ForceBreak
-    || n > 0
-    || m
-    || fr == ForceBreak
+      || n > 0
+  FormatDoc _ _ m1 _ fr1, FormatDoc' fl2 n2 m2 _ _ ->
+    m1
+      || m2
+      || fr1 == ForceBreak
+      || fl2 == ForceBreak
+      || n2 > 0

--- a/src/PureScript/CST/Tidy/Hang.purs
+++ b/src/PureScript/CST/Tidy/Hang.purs
@@ -20,7 +20,7 @@ import Data.Maybe (maybe)
 import Data.Tuple (Tuple(..), uncurry)
 import Dodo (Doc)
 import Dodo as Dodo
-import PureScript.CST.Tidy.Doc (ForceBreak(..), FormatDoc(..), anchor, flexGroup, forceBreak)
+import PureScript.CST.Tidy.Doc (ForceBreak(..), FormatDoc(..), flatten, flexGroup, forceBreak)
 
 data HangingDoc a
   = HangBreak (FormatDoc a)
@@ -190,9 +190,12 @@ toFormatDoc = unHangDoc <<< followLast HangStkRoot
 
   formatInitOp :: FormatDoc a -> HangingDoc a -> HangDoc a
   formatInitOp op doc = case op, hangHead doc of
-    FormatDoc fl1 n1 _ _ fr1, FormatDoc fl2 n2 _ _ _
+    FormatDoc fl1 n1 _ _ fr1, FormatDoc fl2 n2 m2 _ _
       | fl1 /= ForceBreak && n1 == 0 && fr1 /= ForceBreak && fl2 /= ForceBreak && n2 > 0 ->
-          formatInitOp (forceBreak op) (overHangHead anchor doc)
+          formatInitOp (forceBreak op) (overHangHead flatten doc)
+      | HangBreak _ <- doc
+      , fr1 /= ForceBreak && fl2 /= ForceBreak && n2 == 0 && m2 ->
+          formatOp op (followLast HangStkRoot (overHangHead forceBreak doc))
     _, _ ->
       formatOp op (followLast HangStkRoot doc)
 

--- a/test/snapshots/Array.output
+++ b/test/snapshots/Array.output
@@ -19,14 +19,19 @@ bools :: Array Boolean
 bools =
   [ (a && b || c)
   , ( a &&
-        (b || (c && d))
+        ( b ||
+            ( c && d
+            )
+        )
     )
-  , (a && (c && d))
+  , ( a &&
+        ( c && d
+        )
+    )
   ]
 
 strings :: Array String
-strings
-  =
+strings =
   [ "hello"
   , "world"
   , "strings"

--- a/test/snapshots/ForeignImportSignatures.output
+++ b/test/snapshots/ForeignImportSignatures.output
@@ -1,0 +1,42 @@
+module ForeignImportSignatures where
+
+foreign import test :: Foo -> Bar
+
+foreign import test
+  :: Foo
+  -> Bar
+
+foreign import test
+  :: Foo
+    { bar :: Int
+    }
+
+foreign import test
+  :: Foo
+       { bar :: Int
+       }
+  -> Foo
+       { bar :: Int
+       }
+
+-- @format --arrow-last
+module ForeignImportSignatures where
+
+foreign import test :: Foo -> Bar
+
+foreign import test ::
+  Foo ->
+  Bar
+
+foreign import test ::
+  Foo
+    { bar :: Int
+    }
+
+foreign import test ::
+  Foo
+    { bar :: Int
+    } ->
+  Foo
+    { bar :: Int
+    }

--- a/test/snapshots/ForeignImportSignatures.purs
+++ b/test/snapshots/ForeignImportSignatures.purs
@@ -1,0 +1,20 @@
+-- @format --arrow-last
+module ForeignImportSignatures where
+
+foreign import test :: Foo -> Bar
+
+foreign import test :: Foo
+  -> Bar
+
+foreign import test
+  :: Foo
+  { bar :: Int
+  }
+
+foreign import test
+  :: Foo
+  { bar :: Int
+  }
+  -> Foo
+  { bar :: Int
+  }

--- a/test/snapshots/Guards.output
+++ b/test/snapshots/Guards.output
@@ -1,0 +1,53 @@
+module Guards where
+
+test
+  | a = b
+  | otherwise = c
+
+test
+  | a = b
+  | otherwise = c
+
+test
+  | a = b
+  | otherwise = c
+
+test
+  | a =
+      b
+  | otherwise = c
+
+test
+  | a =
+      b
+  | otherwise =
+      c
+
+test = case _ of
+  a
+    | a -> b
+    | otherwise -> c
+
+test = case _ of
+  a
+    | a -> b
+    | otherwise -> c
+
+test = case _ of
+  a
+    | a -> b
+    | otherwise -> c
+
+test = case _ of
+  a
+    | a ->
+        b
+    | otherwise ->
+        c
+
+test = case _ of
+  a
+    | a ->
+        b
+    | otherwise ->
+        c

--- a/test/snapshots/Guards.purs
+++ b/test/snapshots/Guards.purs
@@ -1,0 +1,41 @@
+module Guards where
+
+test
+  | a = b
+  | otherwise = c
+
+test | a = b
+     | otherwise = c
+
+test | a = b | otherwise = c
+
+test | a =
+  b
+  | otherwise = c
+
+test | a =
+  b | otherwise =
+  c
+
+test = case _ of
+  a
+    | a -> b
+    | otherwise -> c
+
+test = case _ of
+  a | a -> b
+    | otherwise -> c
+
+test = case _ of
+  a | a -> b | otherwise -> c
+
+test = case _ of
+  a | a ->
+    b | otherwise ->
+    c
+
+test = case _ of
+  a | a ->
+    b
+    | otherwise ->
+    c

--- a/test/snapshots/IfThenElse.output
+++ b/test/snapshots/IfThenElse.output
@@ -1,0 +1,48 @@
+module IfThenElse where
+
+test = if a then b else c
+
+test =
+  if a then
+    b
+  else c
+
+test =
+  if a then b
+  else c
+
+test =
+  if a then b
+  else c
+
+test = if a then b else if x then c else d
+
+test =
+  if a then
+    b
+  else if x then c
+  else d
+
+test =
+  if a then b
+  else if x then c
+  else d
+
+test =
+  if a then b
+  else if x then c
+  else d
+
+test =
+  if a then
+    b
+  else if x then
+    c
+  else
+    d
+
+test =
+  if a then do
+    b
+  else do
+    c

--- a/test/snapshots/IfThenElse.purs
+++ b/test/snapshots/IfThenElse.purs
@@ -1,0 +1,45 @@
+module IfThenElse where
+
+test = if a then b else c
+
+test = if a then
+  b else c
+
+test = if a
+  then b
+  else c
+
+test =
+  if a
+    then b
+    else c
+
+test = if a then b else if x then c else d
+
+test = if a then
+  b else if x then c else d
+
+test = if a
+  then b
+  else if x
+  then c
+  else d
+
+test =
+  if a then b
+  else if x then c
+  else d
+
+test =
+  if a then
+    b
+  else if x then
+    c
+  else
+    d
+
+test =
+  if a then do
+    b
+  else do
+    c

--- a/test/snapshots/Instance.output
+++ b/test/snapshots/Instance.output
@@ -17,7 +17,7 @@ instance
   append x y = foo x
     y
 
--- @format --arrow-first
+-- @format --arrow-last
 module Instance where
 
 data Foo k

--- a/test/snapshots/Instance.purs
+++ b/test/snapshots/Instance.purs
@@ -1,4 +1,4 @@
--- @format --arrow-first
+-- @format --arrow-last
 module Instance where
 
 data Foo k

--- a/test/snapshots/InstanceChain.output
+++ b/test/snapshots/InstanceChain.output
@@ -10,7 +10,7 @@ instance semigroupFooBlah ::
 else instance semigroupFooBlaz :: Semigroup (Foo k) where
   append x y = x
 
--- @format --arrow-first
+-- @format --arrow-last
 module InstanceChain where
 
 data Foo k

--- a/test/snapshots/InstanceChain.purs
+++ b/test/snapshots/InstanceChain.purs
@@ -1,4 +1,4 @@
--- @format --arrow-first
+-- @format --arrow-last
 module InstanceChain where
 
 data Foo k

--- a/test/snapshots/MultiCase.output
+++ b/test/snapshots/MultiCase.output
@@ -1,0 +1,13 @@
+module MultiCase where
+
+test = case _, _ of
+  Foo a, Bar b ->
+    a <> b
+
+test = case _, _ of
+  Foo a,
+  Bar
+    { b
+    , c
+    } ->
+    a <> b <> c

--- a/test/snapshots/MultiCase.purs
+++ b/test/snapshots/MultiCase.purs
@@ -1,0 +1,11 @@
+module MultiCase where
+
+test = case _, _ of
+  Foo a, Bar b ->
+    a <> b
+
+test = case _, _ of
+  Foo a, Bar { b
+             , c
+             } ->
+    a <> b <> c

--- a/test/snapshots/OperatorsReversed.output
+++ b/test/snapshots/OperatorsReversed.output
@@ -1,11 +1,54 @@
 module OperatorsReversed where
 
+-- The last operand is allowed to break and indent without effecting
+-- the rest of the operator chain.
+test =
+  a <> b <> c <>
+    d
+
+-- A break within the operator chain effects the rest of the chain.
 test =
   a
     <> b
+    <> c
     <>
       d
 
+-- Operator last needs to be flipped back to operator first.
+test =
+  a
+    <> b
+    <> c
+    <>
+      d
+
+-- Multiline delimiters need to retain a break after the operator.
+test =
+  a
+    <>
+      [ 1
+      , 2
+      , 3
+      ]
+    <>
+      [ 1
+      , 2
+      , 3
+      ]
+
+-- Multiline hanging elements need to retain their multiline state.
+test =
+  a
+    #
+      ( \x ->
+          x
+      )
+    #
+      ( \x ->
+          x
+      )
+
+-- For operator first, a break should be inserted after the operator.
 -- Testing together because the rule for collapsing the break affects this.
 test =
   a
@@ -22,13 +65,11 @@ test =
 
 test =
   a
-    <>
-      [ 1
-      , 2
-      , 3
-      ]
-    <>
-      [ 1
-      , 2
-      , 3
-      ]
+    #
+      ( \x ->
+          x
+      )
+    #
+      ( \x ->
+          x
+      )

--- a/test/snapshots/OperatorsReversed.output
+++ b/test/snapshots/OperatorsReversed.output
@@ -1,0 +1,34 @@
+module OperatorsReversed where
+
+test =
+  a
+    <> b
+    <>
+      d
+
+-- Testing together because the rule for collapsing the break affects this.
+test =
+  a
+    <>
+      [ 1
+      , 2
+      , 3
+      ]
+    <>
+      [ 1
+      , 2
+      , 3
+      ]
+
+test =
+  a
+    <>
+      [ 1
+      , 2
+      , 3
+      ]
+    <>
+      [ 1
+      , 2
+      , 3
+      ]

--- a/test/snapshots/OperatorsReversed.purs
+++ b/test/snapshots/OperatorsReversed.purs
@@ -1,10 +1,42 @@
 module OperatorsReversed where
 
+-- The last operand is allowed to break and indent without effecting
+-- the rest of the operator chain.
+test =
+  a <> b <> c <>
+    d
+
+-- A break within the operator chain effects the rest of the chain.
+test =
+  a
+    <> b <> c <>
+    d
+
+-- Operator last needs to be flipped back to operator first.
 test =
   a <>
   b <>
+  c <>
   d
 
+-- Multiline delimiters need to retain a break after the operator.
+test =
+  a <>
+  [ 1
+    , 2, 3 ] <>
+  [ 1
+    , 2, 3 ]
+
+-- Multiline hanging elements need to retain their multiline state.
+test =
+  a #
+  ( \x ->
+      x) #
+  ( \x ->
+      x)
+
+
+-- For operator first, a break should be inserted after the operator.
 -- Testing together because the rule for collapsing the break affects this.
 test =
   a
@@ -14,8 +46,8 @@ test =
     , 2, 3 ]
 
 test =
-  a <>
-  [ 1
-    , 2, 3 ] <>
-  [ 1
-    , 2, 3 ]
+  a
+    # ( \x ->
+      x)
+    # ( \x ->
+      x)

--- a/test/snapshots/OperatorsReversed.purs
+++ b/test/snapshots/OperatorsReversed.purs
@@ -1,0 +1,21 @@
+module OperatorsReversed where
+
+test =
+  a <>
+  b <>
+  d
+
+-- Testing together because the rule for collapsing the break affects this.
+test =
+  a
+    <> [ 1
+    , 2, 3 ]
+    <> [ 1
+    , 2, 3 ]
+
+test =
+  a <>
+  [ 1
+    , 2, 3 ] <>
+  [ 1
+    , 2, 3 ]


### PR DESCRIPTION
I'd like to test this out on a larger codebase before merging.