### PR TITLE
Rewrite hang

### DIFF
--- a/src/PureScript/CST/Tidy.purs
+++ b/src/PureScript/CST/Tidy.purs
@@ -85,18 +85,18 @@ instance formatErrorRecoveredError :: FormatError RecoveredError where
             formatWithComments head.leadingComments last.trailingComments
               $ fromDoc
               $ Dodo.withPosition \{ nextIndent } -> do
-                let
-                  head' =
-                    Dodo.text (printToken UnicodeSource head.value)
-                      <> formatRecoveredComments nextIndent head.trailingComments
-                  init' = init # foldMap \tok ->
-                    formatRecoveredComments nextIndent tok.leadingComments
-                      <> Dodo.text (printToken UnicodeSource tok.value)
-                      <> formatRecoveredComments nextIndent tok.trailingComments
-                  last' =
-                    formatRecoveredComments nextIndent last.leadingComments
-                      <> Dodo.text (printToken UnicodeSource last.value)
-                head' <> init' <> last'
+                  let
+                    head' =
+                      Dodo.text (printToken UnicodeSource head.value)
+                        <> formatRecoveredComments nextIndent head.trailingComments
+                    init' = init # foldMap \tok ->
+                      formatRecoveredComments nextIndent tok.leadingComments
+                        <> Dodo.text (printToken UnicodeSource tok.value)
+                        <> formatRecoveredComments nextIndent tok.trailingComments
+                    last' =
+                      formatRecoveredComments nextIndent last.leadingComments
+                        <> Dodo.text (printToken UnicodeSource last.value)
+                  head' <> init' <> last'
 
           Nothing ->
             formatToken { unicode: UnicodeSource } head

--- a/src/PureScript/CST/Tidy.purs
+++ b/src/PureScript/CST/Tidy.purs
@@ -33,7 +33,7 @@ import Partial.Unsafe (unsafeCrashWith)
 import PureScript.CST.Errors (RecoveredError(..))
 import PureScript.CST.Tidy.Doc (FormatDoc, align, alignCurrentColumn, anchor, blockComment, break, flexDoubleBreak, flexGroup, flexSoftBreak, flexSpaceBreak, forceMinSourceBreaks, fromDoc, indent, joinWith, joinWithMap, leadingLineComment, locally, softBreak, softSpace, sourceBreak, space, spaceBreak, text, trailingLineComment)
 import PureScript.CST.Tidy.Doc (FormatDoc, toDoc) as Exports
-import PureScript.CST.Tidy.Hang (HangingDoc, hang, hangApp, hangBreak, hangConcatApp, hangOps, hangWithIndent)
+import PureScript.CST.Tidy.Hang (HangingDoc, HangingOp(..), hang, hangApp, hangBreak, hangConcatApp, hangOps, hangWithIndent)
 import PureScript.CST.Tidy.Hang as Hang
 import PureScript.CST.Tidy.Precedence (OperatorNamespace(..), OperatorTree(..), PrecedenceMap, QualifiedOperator(..), toOperatorTree)
 import PureScript.CST.Tidy.Token (UnicodeOption(..)) as Exports
@@ -893,7 +893,7 @@ formatCaseBranch conf (Tuple (Separated { head, tail }) guarded) =
 
 formatGuardedExpr :: forall e a. FormatHanging (GuardedExpr e) e a
 formatGuardedExpr conf (GuardedExpr ge@{ patterns: Separated { head, tail }, where: Where { expr, bindings } }) =
-  hangWithIndent (Dodo.align 2 <<< Dodo.indent)
+  hangWithIndent (align 2 <<< indent)
     ( hangBreak
         ( formatToken conf ge.bar
             `space` flexGroup patternGuards
@@ -1033,7 +1033,7 @@ formatRecordLabeled format conf = case _ of
   RecordField label separator value ->
     declareHanging (formatName conf label) (<>) (anchor (formatToken conf separator)) (format conf value)
 
-formatHangingOperatorTree :: forall e a b c. Format b e a -> FormatHanging c e a -> FormatHanging (OperatorTree b c) e a
+formatHangingOperatorTree :: forall e a b c. Format (QualifiedName b) e a -> FormatHanging c e a -> FormatHanging (OperatorTree (QualifiedName b) c) e a
 formatHangingOperatorTree formatOperator format conf = go
   where
   go = case _ of
@@ -1041,7 +1041,10 @@ formatHangingOperatorTree formatOperator format conf = go
     OpList head _ tail ->
       hangOps
         (go head)
-        (map (\(Tuple op b) -> Tuple (formatOperator conf op) (go b)) tail)
+        (map (\(Tuple op b) -> HangingOp (opWidth op) (formatOperator conf op) (go b)) tail)
+
+  opWidth (QualifiedName { token }) =
+    token.range.end.column - token.range.start.column
 
 formatParens :: forall e a b. Format b e a -> Format (Wrapped b) e a
 formatParens format conf (Wrapped { open, value, close }) =

--- a/src/PureScript/CST/Tidy/Doc.purs
+++ b/src/PureScript/CST/Tidy/Doc.purs
@@ -82,10 +82,10 @@ blockComment = splitLines >>> Array.uncons >>> foldMap \{ head, tail } -> do
     prefixSpaces =
       tail
         # Array.mapMaybe
-          ( \str -> do
-              let spaces = SCU.length $ String.takeWhile (eq (String.codePointFromChar ' ')) str
-              guard (spaces < SCU.length str) $> spaces
-          )
+            ( \str -> do
+                let spaces = SCU.length $ String.takeWhile (eq (String.codePointFromChar ' ')) str
+                guard (spaces < SCU.length str) $> spaces
+            )
         # Array.sort
         # Array.head
   case prefixSpaces of

--- a/src/PureScript/CST/Tidy/Doc.purs
+++ b/src/PureScript/CST/Tidy/Doc.purs
@@ -26,6 +26,7 @@ module PureScript.CST.Tidy.Doc
   , flexGroup
   , fromDoc
   , toDoc
+  , mapDoc
   , joinWithMap
   , joinWith
   ) where

--- a/test/snapshots/MultilineApplications.output
+++ b/test/snapshots/MultilineApplications.output
@@ -1,0 +1,76 @@
+module MultilineApplications where
+
+import Prelude
+
+test =
+  do
+    foo
+  bar
+
+test =
+  do
+    foo
+  bar
+
+test =
+  foo
+    #
+      do
+        foo
+      bar
+
+test =
+  foo
+    #
+      do
+        foo
+      bar
+    #
+      do
+        foo
+      bar
+
+test =
+  do
+    foo
+    >>>
+      bar
+
+test =
+  do
+    foo
+    >>>
+      bar
+
+test =
+  foo
+    # do
+        foo
+    >>>
+      bar
+
+test =
+  case foo of
+    Bar -> 42
+    >>>
+      bar
+
+test =
+  case foo of
+    Bar -> 42
+    >>>
+      bar
+
+test =
+  case foo of
+    Bar -> 42
+  bar
+
+test =
+  case foo of
+    Bar -> 42
+  bar
+
+test =
+  foo bar
+    # foo

--- a/test/snapshots/MultilineApplications.purs
+++ b/test/snapshots/MultilineApplications.purs
@@ -1,0 +1,70 @@
+module MultilineApplications where
+
+import Prelude
+
+test =
+  do
+    foo
+  bar
+
+test = do
+    foo
+  bar
+
+test =
+  foo
+    # do
+        foo
+      bar
+
+test =
+  foo
+    # do
+        foo
+      bar
+    # do
+        foo
+      bar
+
+test =
+  do
+    foo
+  >>>
+    bar
+
+test = do
+    foo
+  >>>
+    bar
+
+test =
+  foo
+    # do
+        foo
+      >>>
+        bar
+
+test =
+  case foo of
+    Bar -> 42
+  >>>
+    bar
+
+test = case foo of
+    Bar -> 42
+  >>>
+    bar
+
+test =
+  case foo of
+    Bar -> 42
+  bar
+
+test = case foo of
+    Bar -> 42
+  bar
+
+
+test =
+  foo bar
+    # foo

--- a/test/snapshots/MultilineOperatorArguments.output
+++ b/test/snapshots/MultilineOperatorArguments.output
@@ -1,0 +1,63 @@
+module MultilineOperatorArguments where
+
+test = foo
+  # case _ of
+      Foo -> 42
+  # map
+      ( \a ->
+          a
+      )
+  # map
+      ( \a ->
+          a
+      )
+
+test = foo
+  # case _ of
+      Foo -> 42
+  # map
+      ( \a ->
+          a
+      )
+  #
+    map
+      ( \a ->
+          a
+      )
+
+test = foo
+  # case _ of
+      Foo -> 42
+  # map
+      ( \a ->
+          a
+      )
+  >>> map
+    ( \a ->
+        a
+    )
+
+test = foo
+  # case _ of
+      Foo -> 42
+  # map
+      ( \a ->
+          a
+      )
+  >>>
+    map
+      ( \a ->
+          a
+      )
+
+test =
+  foo
+    >>> case _ of
+      Foo -> 42
+    >>> case _ of
+      Foo -> 42
+    # case _ of
+        Foo -> 42
+
+test = foo # map (\a -> a) # case _ of
+  Foo -> 42

--- a/test/snapshots/MultilineOperatorArguments.purs
+++ b/test/snapshots/MultilineOperatorArguments.purs
@@ -1,0 +1,46 @@
+module MultilineOperatorArguments where
+
+test = foo #
+  case _ of
+            Foo -> 42
+      # map (\a ->
+            a)
+      # map (\a ->
+            a)
+
+test = foo #
+  case _ of
+            Foo -> 42
+      # map (\a ->
+            a)
+      #
+      map (\a ->
+            a)
+
+test = foo #
+  case _ of
+            Foo -> 42
+      # map (\a ->
+            a)
+      >>> map (\a ->
+            a)
+
+test = foo #
+  case _ of
+            Foo -> 42
+      # map (\a ->
+            a)
+      >>>
+      map (\a ->
+            a)
+
+test =
+  foo >>> case _ of
+            Foo -> 42
+      >>> case _ of
+            Foo -> 42
+      # case _ of
+            Foo -> 42
+
+test = foo # map (\a -> a) # case _ of
+                                   Foo -> 42


### PR DESCRIPTION
This rewrites the `Hang` mechanism to be a little more high-level, and properly enumerate all the possible states. This allowed me to add the extra bit of alignment after 1-char operators, which look like delimiters such as `,` or `|`.