### PR TITLE
Fix neoformat example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To enable automatic formatting of the buffer on save, enable `purescript-fmt-on-
 Add to your other fixers `.vimrc` or `$XDG_CONFIG_HOME/neovim/init.vim`
 
 ```viml
-let b:ale_fixers = { 'purescript': [ 'purs-tidy' ] }
+let b:ale_fixers = { 'purescript': [ 'purstidy' ] }
 " suggested to fix on save
 let g:ale_fix_on_save = 1
 ```


### PR DESCRIPTION
The example didn't work for me, the docs at neotfetch mentioned that you shouldn't use the `-` character. So I fixed it <3