### PR TITLE
Fix neoformat instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ let g:ale_fix_on_save = 1
 Add to your `.vimrc` or `$XDG_CONFIG_HOME/neovim/init.vim`
 
 ```viml
-let g:neoformat_enabled_purescript = ['purs-tidy']
+let g:neoformat_enabled_purescript = ['purstidy']
 ```
 
 ### VS Code


### PR DESCRIPTION
Fixes a small typo in the README. The definition in neoformat for purs-tidy doesn't have a hyphen:

https://github.com/sbdchd/neoformat/blob/74c91bb4a84b6a2f160af7d3f6785ef980513566/autoload/neoformat/formatters/purescript.vim#L2