### PR TITLE
`purs-tidy` added to `nixpkgs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A syntax tidy-upper (formatter) for PureScript.
 $ npm install -g purs-tidy
 ```
 
-Also available for [Nix](https://nixos.org/) via [Easy PureScript Nix](https://github.com/justinwoo/easy-purescript-nix)
+Also available for [Nix](https://nixos.org/) via [Nixpkgs 22.11+](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=purs-tidy) and [Easy PureScript Nix](https://github.com/justinwoo/easy-purescript-nix)
 
 ## Usage
 


### PR DESCRIPTION
With [174928](https://github.com/NixOS/nixpkgs/pull/174928) fully merged and [upstreamed](https://nixpk.gs/pr-tracker.html?pr=174928) to `unstable` on Nixpkgs and NixOS, I can confidently say this is supported. I just tested pulling from unstable and it’s golden.

The way `nodePackages` in `nixpkgs` work, any time anyone updates anything in the space, all Node pkgs get updated via `node2nix` + a `generate.sh` script that fetches *all* dependencies. I’m grateful this project doesn’t have dependencies because `node2nix` is sequential and resolving ≈ 400 transitive NPM dependencies takes about 4 hours even on a fast connection. That aside, this pkg will require little to no maintenance and new versions should come in along with other updates to `nodePackages`. The only thing that will really matters is that `purs-tidy` stay compatible with the latest Node LTS.

Unfortunately, it seems I just missed the deadline for `22.05`.

---

Now you should be able to

```console
$ nix-shell -p nodePackages.purs-tidy --run "purs-tidy src/**/*.purs"
```