### PR TITLE
Resolve absolute path to operatorsFile

### DIFF
--- a/bin/Main.purs
+++ b/bin/Main.purs
@@ -348,13 +348,13 @@ resolveRcForDir root = go List.Nil
           case FormatOptions.fromJson =<< parseJson contents' of
             Left jsonError ->
               throwError $ error $ "Could not decode " <> filePath <> ": " <> printJsonDecodeError jsonError
-            Right options -> case options.operatorsFile of
-              Nothing -> pure $ unwind cache (Just options) (List.Cons dir paths)
-              Just file -> do
-                operatorsFile <- liftEffect $ Path.resolve [ dir ] file
-                let
-                  resolvedOptions = options { operatorsFile = Just operatorsFile }
-                pure $ unwind cache (Just resolvedOptions) (List.Cons dir paths)
+            Right options -> do
+              resolvedOptions <- case options.operatorsFile of
+                Nothing ->
+                  pure options
+                Just file ->
+                  liftEffect $ options { operatorsFile = _ } <$> Path.resolve [ dir ] file
+              pure $ unwind cache (Just resolvedOptions) (List.Cons dir paths)
 
   unwind :: RcMap -> Maybe FormatOptions -> List FilePath -> Tuple (Maybe FormatOptions) RcMap
   unwind cache res = case _ of


### PR DESCRIPTION
Fixes #115

I've verified this locally. To verify yourself you can follow the following steps:

Add an empty `.tidyoperators` file in the root of `purescript-tidy`. Modify the existing `.tidyrc.json` to have `"operatorsFile": ".tidyoperators"`. Go to the parent directory for `purescript-tidy`. At this point, formatting `purescript-tidy/src` via the current `purs-tidy` will result in an error. Build this branch and retry with the local script - it should succeed.