### PR TITLE
Resolve absolute path to operatorsFile

### DIFF
--- a/bin/Main.purs
+++ b/bin/Main.purs
@@ -349,10 +349,8 @@ resolveRcForDir root = go List.Nil
             Left jsonError ->
               throwError $ error $ "Could not decode " <> filePath <> ": " <> printJsonDecodeError jsonError
             Right options -> do
-              let
-                resolvedOptions =
-                  options { operatorsFile = Path.relative dir <$> options.operatorsFile }
-              pure $ unwind cache (Just resolvedOptions) (List.Cons dir paths)
+              operatorsFile <- liftEffect $ traverse (Path.resolve [ dir ]) options.operatorsFile
+              pure $ unwind cache (Just options { operatorsFile = operatorsFile }) (List.Cons dir paths)
 
   unwind :: RcMap -> Maybe FormatOptions -> List FilePath -> Tuple (Maybe FormatOptions) RcMap
   unwind cache res = case _ of


### PR DESCRIPTION
Fixes #115

Custom `operatorsFile` configs in .tidyrc were not resolving correctly. Previously we were using `relative dir operatorsFile`, but if `operatorsFile` was a relative path (which is the common case), then the behavior of `relative` is to treat `operatorsFile` as relative to `cwd` initially (I think it's an error that `relative` is typed as a pure function). Thus, this only works (reduntantly) if `cwd` is the same as the `.tidyrc.json` parent directory.

We should be using `resolve [ dir ]` instead to get an absoute path.