### PR TITLE
Add attached derive clause formatting

### DIFF
--- a/bin/spago.yaml
+++ b/bin/spago.yaml
@@ -16,7 +16,7 @@ package:
     - either: ">=6.1.0 <7.0.0"
     - foldable-traversable: ">=6.0.0 <7.0.0"
     - foreign-object: ">=4.1.0 <5.0.0"
-    - language-cst-parser: ">=0.14.1 <0.15.0"
+    - language-cst-parser: "*"
     - lazy: ">=6.0.0 <7.0.0"
     - lists: ">=7.0.0 <8.0.0"
     - maybe: ">=6.0.0 <7.0.0"

--- a/spago.lock
+++ b/spago.lock
@@ -21,7 +21,7 @@
               "foldable-traversable": ">=6.0.0 <7.0.0"
             },
             {
-              "language-cst-parser": ">=0.14.1 <0.15.0"
+              "language-cst-parser": "*"
             },
             {
               "lists": ">=7.0.0 <8.0.0"
@@ -39,7 +39,7 @@
               "partial": ">=4.0.0 <5.0.0"
             },
             {
-              "prelude": ">=6.0.1 <7.0.0"
+              "prelude": ">=6.0.2 <7.0.0"
             },
             {
               "strings": ">=6.0.1 <7.0.0"
@@ -47,53 +47,6 @@
             {
               "tuples": ">=7.0.0 <8.0.0"
             }
-          ],
-          "build_plan": [
-            "ansi",
-            "arrays",
-            "bifunctors",
-            "catenable-lists",
-            "const",
-            "contravariant",
-            "control",
-            "distributive",
-            "dodo-printer",
-            "effect",
-            "either",
-            "enums",
-            "exceptions",
-            "exists",
-            "foldable-traversable",
-            "free",
-            "functions",
-            "functors",
-            "gen",
-            "identity",
-            "integers",
-            "invariant",
-            "language-cst-parser",
-            "lazy",
-            "lists",
-            "maybe",
-            "newtype",
-            "nonempty",
-            "numbers",
-            "ordered-collections",
-            "orders",
-            "partial",
-            "prelude",
-            "profunctor",
-            "refs",
-            "safe-coerce",
-            "st",
-            "strings",
-            "tailrec",
-            "transformers",
-            "tuples",
-            "type-equality",
-            "typelevel-prelude",
-            "unfoldable",
-            "unsafe-coerce"
           ]
         },
         "test": {
@@ -105,80 +58,6 @@
             {
               "tidy-bin": "*"
             }
-          ],
-          "build_plan": [
-            "aff",
-            "ansi",
-            "argonaut-codecs",
-            "argonaut-core",
-            "argparse-basic",
-            "arraybuffer-types",
-            "arrays",
-            "avar",
-            "bifunctors",
-            "catenable-lists",
-            "console",
-            "const",
-            "contravariant",
-            "control",
-            "datetime",
-            "distributive",
-            "dodo-printer",
-            "effect",
-            "either",
-            "enums",
-            "exceptions",
-            "exists",
-            "foldable-traversable",
-            "foreign",
-            "foreign-object",
-            "free",
-            "functions",
-            "functors",
-            "gen",
-            "identity",
-            "integers",
-            "invariant",
-            "js-date",
-            "language-cst-parser",
-            "lazy",
-            "lists",
-            "maybe",
-            "newtype",
-            "node-buffer",
-            "node-event-emitter",
-            "node-fs",
-            "node-glob-basic",
-            "node-path",
-            "node-process",
-            "node-streams",
-            "node-workerbees",
-            "nonempty",
-            "now",
-            "nullable",
-            "numbers",
-            "ordered-collections",
-            "orders",
-            "parallel",
-            "partial",
-            "posix-types",
-            "prelude",
-            "profunctor",
-            "record",
-            "refs",
-            "safe-coerce",
-            "st",
-            "strings",
-            "tailrec",
-            "tidy",
-            "tidy-bin",
-            "transformers",
-            "tuples",
-            "type-equality",
-            "typelevel-prelude",
-            "unfoldable",
-            "unsafe-coerce",
-            "variant"
           ]
         }
       },
@@ -226,7 +105,7 @@
               "foreign-object": ">=4.1.0 <5.0.0"
             },
             {
-              "language-cst-parser": ">=0.14.1 <0.15.0"
+              "language-cst-parser": "*"
             },
             {
               "lazy": ">=6.0.0 <7.0.0"
@@ -294,84 +173,10 @@
             {
               "tuples": ">=7.0.0 <8.0.0"
             }
-          ],
-          "build_plan": [
-            "aff",
-            "ansi",
-            "argonaut-codecs",
-            "argonaut-core",
-            "argparse-basic",
-            "arraybuffer-types",
-            "arrays",
-            "avar",
-            "bifunctors",
-            "catenable-lists",
-            "console",
-            "const",
-            "contravariant",
-            "control",
-            "datetime",
-            "distributive",
-            "dodo-printer",
-            "effect",
-            "either",
-            "enums",
-            "exceptions",
-            "exists",
-            "foldable-traversable",
-            "foreign",
-            "foreign-object",
-            "free",
-            "functions",
-            "functors",
-            "gen",
-            "identity",
-            "integers",
-            "invariant",
-            "js-date",
-            "language-cst-parser",
-            "lazy",
-            "lists",
-            "maybe",
-            "newtype",
-            "node-buffer",
-            "node-event-emitter",
-            "node-fs",
-            "node-glob-basic",
-            "node-path",
-            "node-process",
-            "node-streams",
-            "node-workerbees",
-            "nonempty",
-            "now",
-            "nullable",
-            "numbers",
-            "ordered-collections",
-            "orders",
-            "parallel",
-            "partial",
-            "posix-types",
-            "prelude",
-            "profunctor",
-            "record",
-            "refs",
-            "safe-coerce",
-            "st",
-            "strings",
-            "tailrec",
-            "tidy",
-            "transformers",
-            "tuples",
-            "type-equality",
-            "typelevel-prelude",
-            "unfoldable",
-            "unsafe-coerce",
-            "variant"
           ]
         },
         "test": {
-          "dependencies": [],
-          "build_plan": []
+          "dependencies": []
         }
       },
       "tidy-script": {
@@ -417,96 +222,36 @@
             {
               "unsafe-coerce": ">=6.0.0 <7.0.0"
             }
-          ],
-          "build_plan": [
-            "aff",
-            "arraybuffer-types",
-            "arrays",
-            "bifunctors",
-            "console",
-            "const",
-            "contravariant",
-            "control",
-            "datetime",
-            "distributive",
-            "effect",
-            "either",
-            "enums",
-            "exceptions",
-            "exists",
-            "foldable-traversable",
-            "foreign",
-            "foreign-object",
-            "functions",
-            "functors",
-            "gen",
-            "identity",
-            "integers",
-            "invariant",
-            "js-date",
-            "lazy",
-            "lists",
-            "maybe",
-            "newtype",
-            "node-buffer",
-            "node-child-process",
-            "node-event-emitter",
-            "node-fs",
-            "node-os",
-            "node-path",
-            "node-process",
-            "node-streams",
-            "nonempty",
-            "now",
-            "nullable",
-            "numbers",
-            "ordered-collections",
-            "orders",
-            "parallel",
-            "partial",
-            "posix-types",
-            "prelude",
-            "profunctor",
-            "refs",
-            "safe-coerce",
-            "st",
-            "strings",
-            "tailrec",
-            "transformers",
-            "tuples",
-            "type-equality",
-            "typelevel-prelude",
-            "unfoldable",
-            "unsafe-coerce"
           ]
         },
         "test": {
-          "dependencies": [],
-          "build_plan": []
+          "dependencies": []
         }
       }
     },
-    "extra_packages": {}
+    "extra_packages": {
+      "language-cst-parser": {
+        "path": "../purescript-language-cst-parser"
+      }
+    }
   },
   "packages": {
     "aff": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-5MmdI4+0RHBtSBy+YlU3/Cq4R5W2ih3OaRedJIrVHdk=",
+      "integrity": "sha256-9BRIrSdRoYybfiUmBqgKJ66cPqxYHb277bVWQMn/9sg=",
       "dependencies": [
-        "bifunctors",
         "control",
         "datetime",
         "effect",
         "either",
         "exceptions",
-        "foldable-traversable",
         "functions",
-        "maybe",
         "newtype",
         "parallel",
+        "partial",
         "prelude",
-        "refs",
+        "st",
         "tailrec",
         "transformers",
         "unsafe-coerce"
@@ -515,35 +260,40 @@
     "ansi": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-ZMB6HD+q9CXvn9fRCmJ8dvuDrOVHcjombL3oNOerVnE=",
+      "integrity": "sha256-tOUaXJFzPSfBVAqLI8hc+Tz2M1rg16cXqyHaK/3SmFg=",
       "dependencies": [
         "foldable-traversable",
         "lists",
-        "strings"
+        "prelude"
       ]
     },
     "argonaut-codecs": {
       "type": "registry",
       "version": "9.1.0",
-      "integrity": "sha256-N6efXByUeg848ompEqJfVvZuZPfdRYDGlTDFn0G0Oh8=",
+      "integrity": "sha256-K910SBrmYallESsm8pxJYThs7lig6hxX3M4PW33Cgew=",
       "dependencies": [
         "argonaut-core",
         "arrays",
-        "effect",
+        "bifunctors",
+        "either",
+        "foldable-traversable",
         "foreign-object",
         "identity",
         "integers",
+        "lists",
         "maybe",
         "nonempty",
         "ordered-collections",
         "prelude",
-        "record"
+        "record",
+        "strings",
+        "tuples"
       ]
     },
     "argonaut-core": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-RC82GfAjItydxrO24cdX373KHVZiLqybu19b5X8u7B4=",
+      "integrity": "sha256-gYZihtBIKthVuXXoiPphMookSf8M5aHyFYkcIWqlxTM=",
       "dependencies": [
         "arrays",
         "control",
@@ -561,7 +311,7 @@
     "argparse-basic": {
       "type": "registry",
       "version": "2.0.0",
-      "integrity": "sha256-3Pp8MDfRL2oeBdfxXIUVJBdhGniaahw2UOG4QmHPm58=",
+      "integrity": "sha256-j0HDYapdh4HCvJgt1xBF5Xp2ZU9Pyd5n6spEgPZYkDk=",
       "dependencies": [
         "arrays",
         "bifunctors",
@@ -583,13 +333,13 @@
     "arraybuffer-types": {
       "type": "registry",
       "version": "3.0.2",
-      "integrity": "sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=",
+      "integrity": "sha256-p05cJnSkyeoB7VHzMyc2Eb1RwUaB7Nl0sQSqEGNEUD8=",
       "dependencies": []
     },
     "arrays": {
       "type": "registry",
       "version": "7.3.0",
-      "integrity": "sha256-tmcklBlc/muUtUfr9RapdCPwnlQeB3aSrC4dK85gQlc=",
+      "integrity": "sha256-GD4z7LCi9wzi7FCQqbWhvs8paoUK9NO+HwgXZ+KP8Rk=",
       "dependencies": [
         "bifunctors",
         "control",
@@ -610,20 +360,21 @@
     "avar": {
       "type": "registry",
       "version": "5.0.1",
-      "integrity": "sha256-f+bRR3qQPa/GVe4UbLQiJBy7+PzJkUCwT6qNn0UlkMY=",
+      "integrity": "sha256-8V4SxF4TIWZ9Ik1P4lPzIRUAZeFBe8w5WA2VcCEKsIk=",
       "dependencies": [
         "aff",
         "effect",
         "either",
         "exceptions",
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "bifunctors": {
       "type": "registry",
-      "version": "6.0.0",
-      "integrity": "sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=",
+      "version": "6.1.0",
+      "integrity": "sha256-CvZRb8uI75eKIqiYntR+k05Wk6tKlMS5w8sCA2AFna0=",
       "dependencies": [
         "const",
         "either",
@@ -635,7 +386,7 @@
     "catenable-lists": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=",
+      "integrity": "sha256-7+i/MHBLIRh604iCNT4ENWRWE/wuHIotER4kpdX9Ve0=",
       "dependencies": [
         "control",
         "foldable-traversable",
@@ -649,7 +400,7 @@
     "console": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-CxmAzjgyuGDmt9FZW51VhV6rBPwR6o0YeKUzA9rSzcM=",
+      "integrity": "sha256-3T5PPz1mATZmV0C4GzkCkpLlCa5xG7u8ZNgnLrrrI1Q=",
       "dependencies": [
         "effect",
         "prelude"
@@ -658,7 +409,7 @@
     "const": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=",
+      "integrity": "sha256-S+m0lQsxnji0z1XRUmkn+3RFuWJ5CXWuIr1u3i8Bfoc=",
       "dependencies": [
         "invariant",
         "newtype",
@@ -668,7 +419,7 @@
     "contravariant": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=",
+      "integrity": "sha256-nuckEWqL80NaPmR/l9AUyrfycNh18XcvlZV9PAamwqc=",
       "dependencies": [
         "const",
         "either",
@@ -680,7 +431,7 @@
     "control": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=",
+      "integrity": "sha256-0vxyYh5FL+ilxgLo954w1LqCUC0RSIivNNlb9CaNUQg=",
       "dependencies": [
         "newtype",
         "prelude"
@@ -689,7 +440,7 @@
     "datetime": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=",
+      "integrity": "sha256-tbv6eDXy6QOD7YSknxYSbsDF32OC2JrNbSBpzMs7Doc=",
       "dependencies": [
         "bifunctors",
         "control",
@@ -712,7 +463,7 @@
     "distributive": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=",
+      "integrity": "sha256-netyJK4B32PDYHD0tF2AenKgo3urzbI770ycM0pArAo=",
       "dependencies": [
         "identity",
         "newtype",
@@ -724,7 +475,7 @@
     "dodo-printer": {
       "type": "registry",
       "version": "2.2.3",
-      "integrity": "sha256-+XQtWgt+ybwvQb+QbJ60wm4/hxGRAQoSmeR+Se+ZT7I=",
+      "integrity": "sha256-z6LZV9tXQPBZvHqzUYyCYGB7zHq6u7TOgV6Pr0wiobs=",
       "dependencies": [
         "ansi",
         "either",
@@ -743,7 +494,7 @@
     "effect": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=",
+      "integrity": "sha256-DdqU3bncRTjgMVPPRlAuGHVeajSPEcRaRhNuio7if6s=",
       "dependencies": [
         "prelude"
       ]
@@ -751,7 +502,7 @@
     "either": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=",
+      "integrity": "sha256-tBHx3PgtH4GZOApZCDkcM7szRTYJinrUrVGWazQCUUg=",
       "dependencies": [
         "control",
         "invariant",
@@ -762,7 +513,7 @@
     "enums": {
       "type": "registry",
       "version": "6.0.1",
-      "integrity": "sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=",
+      "integrity": "sha256-sdZOmLX5+5pASGpvVyT0vSD5BBYQjZiayjV5XiPutso=",
       "dependencies": [
         "control",
         "either",
@@ -779,7 +530,7 @@
     "exceptions": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-K0T89IHtF3vBY7eSAO7eDOqSb2J9kZGAcDN5+IKsF8E=",
+      "integrity": "sha256-nRrr+N0wk0TUFOWLR7e1n1oxcXo/X345bQUtoY9lW6A=",
       "dependencies": [
         "effect",
         "either",
@@ -790,7 +541,7 @@
     "exists": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=",
+      "integrity": "sha256-vtLbrWNaI+pzx/2fw2AQnCovoLtcosClIhjO26QKkh8=",
       "dependencies": [
         "unsafe-coerce"
       ]
@@ -798,7 +549,7 @@
     "foldable-traversable": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=",
+      "integrity": "sha256-NGGWyCio/xjce6fPP7y3wwg7CheqllID6aJudDxbWhA=",
       "dependencies": [
         "bifunctors",
         "const",
@@ -816,23 +567,23 @@
     "foreign": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=",
+      "integrity": "sha256-jiDRMVQfovGsbbA/FzbzYf6iWk9i2b5gNrIjz+gFfsI=",
       "dependencies": [
         "either",
         "functions",
-        "identity",
         "integers",
         "lists",
         "maybe",
         "prelude",
         "strings",
-        "transformers"
+        "transformers",
+        "unsafe-coerce"
       ]
     },
     "foreign-object": {
       "type": "registry",
       "version": "4.1.0",
-      "integrity": "sha256-q24okj6mT+yGHYQ+ei/pYPj5ih6sTbu7eDv/WU56JVo=",
+      "integrity": "sha256-x/Q7r80z/vmHRKvPwhYmHP/DnJciPtsyGfRTMzayKIU=",
       "dependencies": [
         "arrays",
         "foldable-traversable",
@@ -845,13 +596,14 @@
         "tailrec",
         "tuples",
         "typelevel-prelude",
-        "unfoldable"
+        "unfoldable",
+        "unsafe-coerce"
       ]
     },
     "free": {
       "type": "registry",
       "version": "7.1.0",
-      "integrity": "sha256-JAumgEsGSzJCNLD8AaFvuX7CpqS5yruCngi6yI7+V5k=",
+      "integrity": "sha256-tUBInfUpRQEw4u94GWcYW7EYdmSdDHSRn88a+C0eltU=",
       "dependencies": [
         "catenable-lists",
         "control",
@@ -872,7 +624,7 @@
     "functions": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=",
+      "integrity": "sha256-0jgtOr+SFO4UScKc40oA/9Vdcf2rLn3h3vZlY0KfqVo=",
       "dependencies": [
         "prelude"
       ]
@@ -880,7 +632,7 @@
     "functors": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=",
+      "integrity": "sha256-W1o/4wcp6S3chodYL8uixlXK2mfr1L+SzM1R+whqUco=",
       "dependencies": [
         "bifunctors",
         "const",
@@ -900,7 +652,7 @@
     "gen": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=",
+      "integrity": "sha256-kyOateeOtQa07vfTMYeSuCKdelgKE1R65fwKkZ10wsY=",
       "dependencies": [
         "either",
         "foldable-traversable",
@@ -917,7 +669,7 @@
     "identity": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=",
+      "integrity": "sha256-RY/iXPpxpqvKHYfJeFVNI1J06kohB9rbtWYuha8t0LE=",
       "dependencies": [
         "control",
         "invariant",
@@ -928,7 +680,7 @@
     "integers": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=",
+      "integrity": "sha256-Y8yozC1uHRLcruobEyv5/bMKzE1BoKJ/olHv6o+bgm8=",
       "dependencies": [
         "maybe",
         "numbers",
@@ -938,7 +690,7 @@
     "invariant": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=",
+      "integrity": "sha256-HyoT1I5qIHRq8RSZji6zZDvqnpVjLw748utrKwZtqsw=",
       "dependencies": [
         "control",
         "prelude"
@@ -947,25 +699,25 @@
     "js-date": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=",
+      "integrity": "sha256-DNQrp4xYc8o80jtxo0aOkUeXGi6h0Xidkk2ZQ8Y4l5Y=",
       "dependencies": [
         "datetime",
         "effect",
-        "exceptions",
+        "enums",
         "foreign",
+        "functions",
         "integers",
-        "now"
+        "maybe",
+        "prelude"
       ]
     },
     "language-cst-parser": {
-      "type": "registry",
-      "version": "0.14.1",
-      "integrity": "sha256-LJzh1ZTaKjcrHx95ZfO2La3w6Xb/IZQT3m2Nuj4n1dM=",
+      "type": "local",
+      "path": "../purescript-language-cst-parser",
       "dependencies": [
         "arrays",
         "const",
         "control",
-        "effect",
         "either",
         "enums",
         "foldable-traversable",
@@ -994,7 +746,7 @@
     "lazy": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=",
+      "integrity": "sha256-MHRC+1Pc+AjortBp4b/e1e6KpEpsDwaJBNBB7TOL+1I=",
       "dependencies": [
         "control",
         "foldable-traversable",
@@ -1005,7 +757,7 @@
     "lists": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=",
+      "integrity": "sha256-/mGd7wLoU+wsTcqii7SSUByxsvwvjnu2PjwAD47yYb4=",
       "dependencies": [
         "bifunctors",
         "control",
@@ -1024,7 +776,7 @@
     "maybe": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=",
+      "integrity": "sha256-8X6XEgtZ5lqfkEuc1hWOofnL6mwhk8gSJTxwvbR/SbY=",
       "dependencies": [
         "control",
         "invariant",
@@ -1035,7 +787,7 @@
     "newtype": {
       "type": "registry",
       "version": "5.0.0",
-      "integrity": "sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=",
+      "integrity": "sha256-dt6w0cty4OS+Pjt9fsh3iU6ottqSU83mdAZkaEEvo6c=",
       "dependencies": [
         "prelude",
         "safe-coerce"
@@ -1044,12 +796,15 @@
     "node-buffer": {
       "type": "registry",
       "version": "9.0.0",
-      "integrity": "sha256-PWE2DJ5ruBLCmeA/fUiuySEFmUJ/VuRfyrnCuVZBlu4=",
+      "integrity": "sha256-RdQjilmEHqsT4fwpCr8Mavw8KTafYrS3ZM6zeAAVAl8=",
       "dependencies": [
         "arraybuffer-types",
         "effect",
+        "functions",
         "maybe",
         "nullable",
+        "partial",
+        "prelude",
         "st",
         "unsafe-coerce"
       ]
@@ -1057,25 +812,36 @@
     "node-child-process": {
       "type": "registry",
       "version": "11.1.0",
-      "integrity": "sha256-vioMNgk8p+CGwlb6T3I3TIir27el85Yg4satLE/I89w=",
+      "integrity": "sha256-Um7g75gXKEX51ZlviJWocTjUENUW1qHgqGqhYKkka74=",
       "dependencies": [
+        "aff",
+        "datetime",
+        "effect",
+        "either",
         "exceptions",
         "foreign",
         "foreign-object",
         "functions",
+        "maybe",
+        "node-buffer",
         "node-event-emitter",
         "node-fs",
         "node-os",
         "node-streams",
         "nullable",
+        "parallel",
+        "partial",
         "posix-types",
+        "prelude",
+        "refs",
+        "safe-coerce",
         "unsafe-coerce"
       ]
     },
     "node-event-emitter": {
       "type": "registry",
       "version": "3.0.0",
-      "integrity": "sha256-Qw0MjsT4xRH2j2i4K8JmRjcMKnH5z1Cw39t00q4LE4w=",
+      "integrity": "sha256-wodx71NxJBPXOaawFn01V1ByYB2vT+I3RuV2giOVKMg=",
       "dependencies": [
         "effect",
         "either",
@@ -1089,8 +855,9 @@
     "node-fs": {
       "type": "registry",
       "version": "9.2.0",
-      "integrity": "sha256-Sg0vkXycEzkEerX6hLccz21Ygd9w1+QSk1thotRZPGI=",
+      "integrity": "sha256-fxioTSm9y47WuYs9F/7nxCh/RVDCl3Kr3Hg779J4SJA=",
       "dependencies": [
+        "aff",
         "datetime",
         "effect",
         "either",
@@ -1106,14 +873,13 @@
         "nullable",
         "partial",
         "prelude",
-        "strings",
-        "unsafe-coerce"
+        "strings"
       ]
     },
     "node-glob-basic": {
       "type": "registry",
       "version": "2.0.0",
-      "integrity": "sha256-COPsHFpqwFGOBbo3DZ4yQLp5UTNshLcINIV2P3h8g6o=",
+      "integrity": "sha256-bGqHSBqz99RgUAuoFEllfm5dIlNBGV6x1QSXbQhsbLk=",
       "dependencies": [
         "aff",
         "effect",
@@ -1135,17 +901,15 @@
     "node-os": {
       "type": "registry",
       "version": "5.1.0",
-      "integrity": "sha256-K3gcu9AXanN1+qtk1900+Fi+CuO0s3/H/RMNRNgIzso=",
+      "integrity": "sha256-UtQiPiZy5ouV832ubww/U8KlpVYny9xsW8WWfYOEgtA=",
       "dependencies": [
         "arrays",
         "bifunctors",
-        "console",
         "control",
         "datetime",
         "effect",
         "either",
         "exceptions",
-        "foldable-traversable",
         "foreign",
         "foreign-object",
         "functions",
@@ -1161,7 +925,7 @@
     "node-path": {
       "type": "registry",
       "version": "5.0.1",
-      "integrity": "sha256-ePOElFamHkffhwJcS0Ozq4A14rflnkasFU6X2B8/yXs=",
+      "integrity": "sha256-j7n/SmpVz0FOMJl4XZop3ofJ+MeIPkMNqUEUKHEL6Us=",
       "dependencies": [
         "effect"
       ]
@@ -1169,23 +933,25 @@
     "node-process": {
       "type": "registry",
       "version": "11.2.0",
-      "integrity": "sha256-+2MQDYChjGbVbapCyJtuWYwD41jk+BntF/kcOTKBMVs=",
+      "integrity": "sha256-onzKeNmaeYfN3HSDPqSFTrrP2Yl9tnVsfKKhnf2plxM=",
       "dependencies": [
         "effect",
+        "exceptions",
         "foreign",
         "foreign-object",
         "maybe",
         "node-event-emitter",
         "node-streams",
+        "nullable",
         "posix-types",
         "prelude",
-        "unsafe-coerce"
+        "strings"
       ]
     },
     "node-streams": {
       "type": "registry",
       "version": "9.0.1",
-      "integrity": "sha256-7RJ6RqjOlhW+QlDFQNUHlkCG/CuYTTLT8yary5jhhsU=",
+      "integrity": "sha256-yuVGm/R/tBr4Nphi+a1a984Z0fkmN9Q5wWtSmbmJTpA=",
       "dependencies": [
         "aff",
         "arrays",
@@ -1206,7 +972,7 @@
     "node-workerbees": {
       "type": "registry",
       "version": "0.3.1",
-      "integrity": "sha256-EoyDKWQpD9Wc/j/068HcOcQ8F/+2KVX+7F+RT+gNq3Y=",
+      "integrity": "sha256-jpYs0T2IUsp1uT1OI4M38Nr63km1vdzfg8LxYj21JKQ=",
       "dependencies": [
         "aff",
         "argonaut-core",
@@ -1229,7 +995,7 @@
     "nonempty": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=",
+      "integrity": "sha256-Ctkq8/+KiGqCE53Y/LvibA/coy7ev9HtRZU+GYS7yfQ=",
       "dependencies": [
         "control",
         "foldable-traversable",
@@ -1239,47 +1005,42 @@
         "unfoldable"
       ]
     },
-    "now": {
-      "type": "registry",
-      "version": "6.0.0",
-      "integrity": "sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=",
-      "dependencies": [
-        "datetime",
-        "effect"
-      ]
-    },
     "nullable": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=",
+      "integrity": "sha256-CDAZk+L9Sc0GCFTkE8n+qdp4Ys8avvnkU+m2hVALt7M=",
       "dependencies": [
-        "effect",
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "numbers": {
       "type": "registry",
       "version": "9.0.1",
-      "integrity": "sha256-/9M6aeMDBdB4cwYDeJvLFprAHZ49EbtKQLIJsneXLIk=",
+      "integrity": "sha256-ZydYckgwRAnRaFC7pu6fADhzdwX+UqHZrfJyet64zls=",
       "dependencies": [
         "functions",
-        "maybe"
+        "maybe",
+        "prelude"
       ]
     },
     "ordered-collections": {
       "type": "registry",
       "version": "3.2.0",
-      "integrity": "sha256-o9jqsj5rpJmMdoe/zyufWHFjYYFTTsJpgcuCnqCO6PM=",
+      "integrity": "sha256-NaEXc2cz/7lJfxPWEja4XlZbGxuRqJwFKQJjsJf51kQ=",
       "dependencies": [
         "arrays",
+        "control",
         "foldable-traversable",
+        "functions",
         "gen",
         "lists",
         "maybe",
+        "newtype",
         "partial",
         "prelude",
-        "st",
+        "safe-coerce",
         "tailrec",
         "tuples",
         "unfoldable"
@@ -1288,7 +1049,7 @@
     "orders": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=",
+      "integrity": "sha256-nSMxZK7wxyDULkjZqvMyB71mVo6b0AyLLHosDVbv1XM=",
       "dependencies": [
         "newtype",
         "prelude"
@@ -1297,7 +1058,7 @@
     "parallel": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=",
+      "integrity": "sha256-bAGpVhrFz2IyHkA4MR7+tE/19FZ7dzYBdYPgK5svkqw=",
       "dependencies": [
         "control",
         "effect",
@@ -1315,28 +1076,29 @@
     "partial": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=",
+      "integrity": "sha256-mdrlJBAgFMh79hNRW39uv7c+BwnnaOrAMmdh7+VhEhs=",
       "dependencies": []
     },
     "posix-types": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-ZfFz8RR1lee/o/Prccyeut3Q+9tYd08mlR72sIh6GzA=",
+      "integrity": "sha256-Je5jG439F/SFO/IvVevZnWVxDIonrehlKuJkefP2lHE=",
       "dependencies": [
         "maybe",
+        "newtype",
         "prelude"
       ]
     },
     "prelude": {
       "type": "registry",
-      "version": "6.0.1",
-      "integrity": "sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=",
+      "version": "6.0.2",
+      "integrity": "sha256-IqykrDRquGUD/LRSad7y75hZv3bUsGQ4knc8tdez8Qw=",
       "dependencies": []
     },
     "profunctor": {
       "type": "registry",
       "version": "6.0.1",
-      "integrity": "sha256-E58hSYdJvF2Qjf9dnWLPlJKh2Z2fLfFLkQoYi16vsFk=",
+      "integrity": "sha256-Ow0mJC+PIIRq/a3mzCWY5vxuTgR/e+Ee68+mWeSRnWY=",
       "dependencies": [
         "control",
         "distributive",
@@ -1351,7 +1113,7 @@
     "record": {
       "type": "registry",
       "version": "4.0.0",
-      "integrity": "sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=",
+      "integrity": "sha256-WQ8fqp4X1wTA70J4qUcPW4Z7DCwx6e5KJnT/EuTdWSc=",
       "dependencies": [
         "functions",
         "prelude",
@@ -1361,7 +1123,7 @@
     "refs": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=",
+      "integrity": "sha256-KKD5G9dR2SauuDGULUJsxjqDOEi1Jqm+2Sq5U2mY8YU=",
       "dependencies": [
         "effect",
         "prelude"
@@ -1370,7 +1132,7 @@
     "safe-coerce": {
       "type": "registry",
       "version": "2.0.0",
-      "integrity": "sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=",
+      "integrity": "sha256-EJrxtKt5xC7TYjBZrSBO/J7Aw3DmtilYjt4olpAXWVc=",
       "dependencies": [
         "unsafe-coerce"
       ]
@@ -1378,8 +1140,9 @@
     "st": {
       "type": "registry",
       "version": "6.2.0",
-      "integrity": "sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=",
+      "integrity": "sha256-WI4MEkkwUd4pnwZQ3G8VKWgX5t1RSNJludm5e9boaRo=",
       "dependencies": [
+        "effect",
         "partial",
         "prelude",
         "tailrec",
@@ -1389,7 +1152,7 @@
     "strings": {
       "type": "registry",
       "version": "6.0.1",
-      "integrity": "sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=",
+      "integrity": "sha256-FNto2hoNW5Da6W6crIk77YXMagBvOGHZE1kO7eZ1vLM=",
       "dependencies": [
         "arrays",
         "control",
@@ -1412,7 +1175,7 @@
     "tailrec": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=",
+      "integrity": "sha256-xrorCfP0xV1wubs27idQCHQqdvSUuqmmL/am7Ji1wVU=",
       "dependencies": [
         "bifunctors",
         "effect",
@@ -1427,7 +1190,7 @@
     "transformers": {
       "type": "registry",
       "version": "6.1.0",
-      "integrity": "sha256-3Bm+Z6tsC/paG888XkywDngJ2JMos+JfOhRlkVfb7gI=",
+      "integrity": "sha256-QJmgNT/y7ljPHSsXaW4zxF/982BFiQ90KNL1g/NtEOQ=",
       "dependencies": [
         "control",
         "distributive",
@@ -1449,7 +1212,7 @@
     "tuples": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=",
+      "integrity": "sha256-BKy7EfK8S1KeTCwyWqyW1wwcpSAQuh3IsczSVgS6fzY=",
       "dependencies": [
         "control",
         "invariant",
@@ -1459,13 +1222,13 @@
     "type-equality": {
       "type": "registry",
       "version": "4.0.1",
-      "integrity": "sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=",
+      "integrity": "sha256-BBqYOSnAKmayRvR5mtZoCf4SlYs2ipatD/+5nQx73aw=",
       "dependencies": []
     },
     "typelevel-prelude": {
       "type": "registry",
       "version": "7.0.0",
-      "integrity": "sha256-uFF2ph+vHcQpfPuPf2a3ukJDFmLhApmkpTMviHIWgJM=",
+      "integrity": "sha256-+pHi14/40mTj/+lmCWqL0T7iXIXD1+NSg/KItyyoB0A=",
       "dependencies": [
         "prelude",
         "type-equality"
@@ -1474,7 +1237,7 @@
     "unfoldable": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=",
+      "integrity": "sha256-BK/6By1sKp/ztk+9CF3q43SV0QDTLVdsGqFerKHSmbg=",
       "dependencies": [
         "foldable-traversable",
         "maybe",
@@ -1486,21 +1249,22 @@
     "unsafe-coerce": {
       "type": "registry",
       "version": "6.0.0",
-      "integrity": "sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=",
+      "integrity": "sha256-0L1QsaY20OILjfU5TV72d3U/tSjhmL9hJ32WMp857Lk=",
       "dependencies": []
     },
     "variant": {
       "type": "registry",
       "version": "8.0.0",
-      "integrity": "sha256-SR//zQDg2dnbB8ZHslcxieUkCeNlbMToapvmh9onTtw=",
+      "integrity": "sha256-Ydrgl8liWEwYQOWW76PdZtg3vxKpoKgsnmFyTLgZkoU=",
       "dependencies": [
+        "control",
         "enums",
+        "foldable-traversable",
         "lists",
         "maybe",
         "partial",
         "prelude",
-        "record",
-        "tuples",
+        "type-equality",
         "unsafe-coerce"
       ]
     }

--- a/spago.yaml
+++ b/spago.yaml
@@ -15,13 +15,13 @@ package:
     - dodo-printer: ">=2.2.3 <3.0.0"
     - either: ">=6.1.0 <7.0.0"
     - foldable-traversable: ">=6.0.0 <7.0.0"
-    - language-cst-parser: ">=0.14.1 <0.15.0"
+    - language-cst-parser: "*"
     - lists: ">=7.0.0 <8.0.0"
     - maybe: ">=6.0.0 <7.0.0"
     - newtype: ">=5.0.0 <6.0.0"
     - ordered-collections: ">=3.2.0 <4.0.0"
     - partial: ">=4.0.0 <5.0.0"
-    - prelude: ">=6.0.1 <7.0.0"
+    - prelude: ">=6.0.2 <7.0.0"
     - strings: ">=6.0.1 <7.0.0"
     - tuples: ">=7.0.0 <8.0.0"
   test:
@@ -32,4 +32,7 @@ package:
       - node-glob-basic
       - node-path
       - tidy-bin: "*"
-workspace: {}
+workspace:
+  extraPackages:
+    language-cst-parser:
+      path: ../purescript-language-cst-parser

--- a/src/Tidy.purs
+++ b/src/Tidy.purs
@@ -33,7 +33,7 @@ import Data.Tuple (Tuple(..), fst, snd)
 import Dodo as Dodo
 import Partial.Unsafe (unsafeCrashWith)
 import PureScript.CST.Errors (RecoveredError(..))
-import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), ClassHead, Comment(..), DataCtor(..), DataHead, DataMembers(..), Declaration(..), Delimited, DelimitedNonEmpty, DerivingClassHead(..), DerivingClause(..), DoStatement(..), Export(..), Expr(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Ident, IfThenElse, Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), InstanceHead, Label, Labeled(..), LetBinding(..), LineFeed, Module(..), ModuleBody(..), ModuleHeader(..), ModuleName, Name(..), OneOrDelimited(..), Operator, PatternGuard(..), Prefixed(..), Proper, QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), SourceStyle(..), SourceToken, Token(..), Type(..), TypeVarBinding(..), ValueBindingFields, Where(..), Wrapped(..))
+import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), ClassHead, Comment(..), DataCtor(..), DataHead, DataMembers(..), Declaration(..), Delimited, DelimitedNonEmpty, DeriveClassHead(..), DeriveClause(..), DoStatement(..), Export(..), Expr(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Ident, IfThenElse, Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), InstanceHead, Label, Labeled(..), LetBinding(..), LineFeed, Module(..), ModuleBody(..), ModuleHeader(..), ModuleName, Name(..), OneOrDelimited(..), Operator, PatternGuard(..), Prefixed(..), Proper, QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), SourceStyle(..), SourceToken, Token(..), Type(..), TypeVarBinding(..), ValueBindingFields, Where(..), Wrapped(..))
 import Tidy.Doc (FormatDoc, align, alignCurrentColumn, anchor, break, flexDoubleBreak, flexGroup, flexSoftBreak, flexSpaceBreak, forceMinSourceBreaks, fromDoc, indent, joinWith, joinWithMap, leadingBlockComment, leadingLineComment, locally, softBreak, softSpace, sourceBreak, space, spaceBreak, text, trailingBlockComment, trailingLineComment)
 import Tidy.Doc (FormatDoc, toDoc) as Exports
 import Tidy.Doc as Doc
@@ -525,29 +525,29 @@ formatDataHead conf { keyword, name, vars } =
     anchor (formatName conf name)
       `flexSpaceBreak` joinWithMap spaceBreak (formatTypeVarBindingPlain conf) vars
 
-formatDeclWithDerivs :: forall e a. FormatOptions e a -> Array (DerivingClause e) -> FormatDoc a -> FormatDoc a
+formatDeclWithDerivs :: forall e a. FormatOptions e a -> Array (DeriveClause e) -> FormatDoc a -> FormatDoc a
 formatDeclWithDerivs conf derivs declDoc =
   case derivs of
     [] -> declDoc
-    _ -> declDoc `break` indent (joinWithMap break (formatDerivingClause conf) derivs)
+    _ -> declDoc `break` indent (joinWithMap break (formatDeriveClause conf) derivs)
 
-formatDerivingClause :: forall e a. Format (DerivingClause e) e a
-formatDerivingClause conf = case _ of
-  DerivingClauseStandard kw classes ->
+formatDeriveClause :: forall e a. Format (DeriveClause e) e a
+formatDeriveClause conf = case _ of
+  DeriveClauseStandard kw classes ->
     formatToken conf kw
-      `space` anchor (formatParenListNonEmpty Grouped formatDerivingClassHead conf classes)
-  DerivingClauseNewtype kw nt classes ->
+      `space` anchor (formatParenListNonEmpty Grouped formatDeriveClassHead conf classes)
+  DeriveClauseNewtype kw nt classes ->
     formatToken conf kw
       `space` anchor (formatToken conf nt)
-      `space` anchor (formatParenListNonEmpty Grouped formatDerivingClassHead conf classes)
-  DerivingClauseVia kw classes viaTok viaTy ->
+      `space` anchor (formatParenListNonEmpty Grouped formatDeriveClassHead conf classes)
+  DeriveClauseVia kw classes viaTok viaTy ->
     formatToken conf kw
-      `space` anchor (formatParenListNonEmpty Grouped formatDerivingClassHead conf classes)
+      `space` anchor (formatParenListNonEmpty Grouped formatDeriveClassHead conf classes)
       `space` anchor (formatToken conf viaTok)
       `space` anchor (formatType conf viaTy)
 
-formatDerivingClassHead :: forall e a. Format (DerivingClassHead e) e a
-formatDerivingClassHead conf (DerivingClassHead { className, args }) =
+formatDeriveClassHead :: forall e a. Format (DeriveClassHead e) e a
+formatDeriveClassHead conf (DeriveClassHead { className, args }) =
   case args of
     [] -> formatQualifiedName conf className
     _ ->

--- a/src/Tidy.purs
+++ b/src/Tidy.purs
@@ -33,7 +33,7 @@ import Data.Tuple (Tuple(..), fst, snd)
 import Dodo as Dodo
 import Partial.Unsafe (unsafeCrashWith)
 import PureScript.CST.Errors (RecoveredError(..))
-import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), ClassHead, Comment(..), DataCtor(..), DataHead, DataMembers(..), Declaration(..), Delimited, DelimitedNonEmpty, DoStatement(..), Export(..), Expr(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Ident, IfThenElse, Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), InstanceHead, Label, Labeled(..), LetBinding(..), LineFeed, Module(..), ModuleBody(..), ModuleHeader(..), ModuleName, Name(..), OneOrDelimited(..), Operator, PatternGuard(..), Prefixed(..), Proper, QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), SourceStyle(..), SourceToken, Token(..), Type(..), TypeVarBinding(..), ValueBindingFields, Where(..), Wrapped(..))
+import PureScript.CST.Types (AppSpine(..), Binder(..), ClassFundep(..), ClassHead, Comment(..), DataCtor(..), DataHead, DataMembers(..), Declaration(..), Delimited, DelimitedNonEmpty, DerivingClassHead(..), DerivingClause(..), DoStatement(..), Export(..), Expr(..), FixityOp(..), Foreign(..), Guarded(..), GuardedExpr(..), Ident, IfThenElse, Import(..), ImportDecl(..), Instance(..), InstanceBinding(..), InstanceHead, Label, Labeled(..), LetBinding(..), LineFeed, Module(..), ModuleBody(..), ModuleHeader(..), ModuleName, Name(..), OneOrDelimited(..), Operator, PatternGuard(..), Prefixed(..), Proper, QualifiedName(..), RecordLabeled(..), RecordUpdate(..), Row(..), Separated(..), SourceStyle(..), SourceToken, Token(..), Type(..), TypeVarBinding(..), ValueBindingFields, Where(..), Wrapped(..))
 import Tidy.Doc (FormatDoc, align, alignCurrentColumn, anchor, break, flexDoubleBreak, flexGroup, flexSoftBreak, flexSpaceBreak, forceMinSourceBreaks, fromDoc, indent, joinWith, joinWithMap, leadingBlockComment, leadingLineComment, locally, softBreak, softSpace, sourceBreak, space, spaceBreak, text, trailingBlockComment, trailingLineComment)
 import Tidy.Doc (FormatDoc, toDoc) as Exports
 import Tidy.Doc as Doc
@@ -377,24 +377,26 @@ formatImport conf = case _ of
 
 formatDecl :: forall e a. Format (Declaration e) e a
 formatDecl conf = case _ of
-  DeclData head (Just (Tuple equals (Separated ctors))) ->
-    if Array.null ctors.tail then
-      declareHanging
-        (formatDataHead conf head)
-        space
-        (anchor (formatToken conf equals))
-        (formatHangingDataCtor conf ctors.head)
-    else
-      formatDataHead conf head `flexSpaceBreak` indent do
-        formatDataElem (Tuple equals ctors.head)
-          `spaceBreak` joinWithMap spaceBreak formatDataElem ctors.tail
+  DeclData head (Just (Tuple equals (Separated ctors))) derivs ->
+    formatDeclWithDerivs conf derivs do
+      if Array.null ctors.tail then
+        declareHanging
+          (formatDataHead conf head)
+          space
+          (anchor (formatToken conf equals))
+          (formatHangingDataCtor conf ctors.head)
+      else
+        formatDataHead conf head `flexSpaceBreak` indent do
+          formatDataElem (Tuple equals ctors.head)
+            `spaceBreak` joinWithMap spaceBreak formatDataElem ctors.tail
     where
     formatDataElem (Tuple a b) =
       formatToken conf a
         `space` formatListElem 2 formatDataCtor conf b
 
-  DeclData head _ ->
-    formatDataHead conf head
+  DeclData head _ derivs ->
+    formatDeclWithDerivs conf derivs do
+      formatDataHead conf head
 
   DeclType head equals ty ->
     declareHanging
@@ -403,12 +405,13 @@ formatDecl conf = case _ of
       (anchor (formatToken conf equals))
       (formatHangingType conf ty)
 
-  DeclNewtype head equals name ty ->
-    declareHanging
-      (formatDataHead conf head)
-      space
-      (anchor (formatToken conf equals))
-      (formatHangingDataCtor conf (DataCtor { name, fields: [ ty ] }))
+  DeclNewtype head equals name ty derivs ->
+    formatDeclWithDerivs conf derivs do
+      declareHanging
+        (formatDataHead conf head)
+        space
+        (anchor (formatToken conf equals))
+        (formatHangingDataCtor conf (DataCtor { name, fields: [ ty ] }))
 
   DeclRole kw1 kw2 name rls ->
     flatten $ words <> NonEmptyArray.toArray roles
@@ -521,6 +524,35 @@ formatDataHead conf { keyword, name, vars } =
   formatToken conf keyword `space` indent do
     anchor (formatName conf name)
       `flexSpaceBreak` joinWithMap spaceBreak (formatTypeVarBindingPlain conf) vars
+
+formatDeclWithDerivs :: forall e a. FormatOptions e a -> Array (DerivingClause e) -> FormatDoc a -> FormatDoc a
+formatDeclWithDerivs conf derivs declDoc =
+  case derivs of
+    [] -> declDoc
+    _ -> declDoc `break` indent (joinWithMap break (formatDerivingClause conf) derivs)
+
+formatDerivingClause :: forall e a. Format (DerivingClause e) e a
+formatDerivingClause conf = case _ of
+  DerivingClauseStandard kw classes ->
+    formatToken conf kw
+      `space` anchor (formatParenListNonEmpty Grouped formatDerivingClassHead conf classes)
+  DerivingClauseNewtype kw nt classes ->
+    formatToken conf kw
+      `space` anchor (formatToken conf nt)
+      `space` anchor (formatParenListNonEmpty Grouped formatDerivingClassHead conf classes)
+  DerivingClauseVia kw classes viaTok viaTy ->
+    formatToken conf kw
+      `space` anchor (formatParenListNonEmpty Grouped formatDerivingClassHead conf classes)
+      `space` anchor (formatToken conf viaTok)
+      `space` anchor (formatType conf viaTy)
+
+formatDerivingClassHead :: forall e a. Format (DerivingClassHead e) e a
+formatDerivingClassHead conf (DerivingClassHead { className, args }) =
+  case args of
+    [] -> formatQualifiedName conf className
+    _ ->
+      formatQualifiedName conf className
+        `space` joinWithMap space (formatType conf) args
 
 formatDataCtor :: forall e a. Format (DataCtor e) e a
 formatDataCtor conf = Hang.toFormatDoc <<< formatHangingDataCtor conf
@@ -1339,9 +1371,9 @@ formatTopLevelGroups = formatDeclGroups topDeclGroupSeparator topDeclGroup forma
     _, _ -> DeclGroupSoft
 
   topDeclGroup = case _ of
-    DeclData { name: Name { name } } _ -> DeclGroupType name
+    DeclData { name: Name { name } } _ _ -> DeclGroupType name
     DeclType { name: Name { name } } _ _ -> DeclGroupType name
-    DeclNewtype { name: Name { name } } _ _ _ -> DeclGroupType name
+    DeclNewtype { name: Name { name } } _ _ _ _ -> DeclGroupType name
     DeclClass { name: Name { name } } _ -> DeclGroupClass name
     DeclKindSignature _ (Labeled { label: Name { name } }) -> DeclGroupTypeSignature name
     DeclSignature (Labeled { label: Name { name } }) -> DeclGroupValueSignature name

--- a/test/snapshots/DerivingClauses.input
+++ b/test/snapshots/DerivingClauses.input
@@ -1,0 +1,21 @@
+module DerivingClauses where
+
+import Prelude
+
+newtype TodoId = TodoId String
+  derive (Newtype)
+
+newtype TodoTitle = TodoTitle String
+  derive (Newtype)
+  derive newtype (Eq, Ord, Show)
+
+newtype Wrapped = Wrapped Int
+  derive (Eq, Ord, Show) via Int
+
+data Color = Red | Green | Blue
+  derive (Eq, Ord, Show)
+
+newtype UserId = UserId String
+  derive (Newtype)
+  derive newtype (Eq, Ord, Show)
+  derive (ReadForeign, WriteForeign) via String

--- a/test/snapshots/DerivingClauses.output
+++ b/test/snapshots/DerivingClauses.output
@@ -1,0 +1,21 @@
+module DerivingClauses where
+
+import Prelude
+
+newtype TodoId = TodoId String
+  derive (Newtype)
+
+newtype TodoTitle = TodoTitle String
+  derive (Newtype)
+  derive newtype (Eq, Ord, Show)
+
+newtype Wrapped = Wrapped Int
+  derive (Eq, Ord, Show) via Int
+
+data Color = Red | Green | Blue
+  derive (Eq, Ord, Show)
+
+newtype UserId = UserId String
+  derive (Newtype)
+  derive newtype (Eq, Ord, Show)
+  derive (ReadForeign, WriteForeign) via String


### PR DESCRIPTION
> [!WARNING]
> This PR was AI-generated. If that's not okay close it! I'm just trying to make PureScript even nicer

## Summary
- Adds formatting for `derive (Class)`, `derive newtype (Class)`, and `derive (Class) via Type` clauses
- Derive clauses are indented under their parent data/newtype declaration
- Uses `Grouped` layout so class lists stay on one line when they fit
- All existing tests pass, new snapshot test added

Depends on natefaubion/purescript-language-cst-parser (attached-derive-clauses branch).
Companion to purescript/purescript#4592